### PR TITLE
Update format so that jrtc app python modules are specified in deploy…

### DIFF
--- a/jrtc_apps/xran_packets/deployment.yaml
+++ b/jrtc_apps/xran_packets/deployment.yaml
@@ -14,6 +14,8 @@ app:
     path: ${JRTC_APPS}/xran_packets/xran_packets.py
     type: python
     port: 3001
+    modules:
+      - ${JBPF_CODELETS}/xran_packets/xran_packet_info.py
 
 jbpf:
   device:

--- a/jrtc_apps/xran_packets/xran_packets.py
+++ b/jrtc_apps/xran_packets/xran_packets.py
@@ -15,18 +15,9 @@ sys.path.append(f"{JRTC_APP_PATH}")
 import jrtc_app
 from jrtc_app import *
 
-JRTC_PATH = f'{os.environ.get("JRTC_PATH")}'
-if JRTC_PATH is None:
-    raise ValueError("JRTC_PATH not set")
-
-
-JBPF_CODELETS = os.environ.get("JBPF_CODELETS")
-if JBPF_CODELETS is None:
-    raise ValueError("JBPF_CODELETS not set")
-PROTO_PATH = f'{JBPF_CODELETS}/xran_packets'
-sys.path.append(PROTO_PATH)
+# Import the xran_packet_info module
+xran_packet_info = sys.modules.get('xran_packet_info')
 from xran_packet_info import struct__packet_stats
-
 
 
 ##########################################################################


### PR DESCRIPTION
Update format so that jrtc app python modules are specified in deployment yaml.

See jrtc_apps/xran_packets.

The deployment is updated as below ....

    modules:
      - ${JBPF_CODELETS}/xran_packets/xran_packet_info.py

In the python file, the module is loaded as below ...

# Import the xran_packet_info module
xran_packet_info = sys.modules.get('xran_packet_info')
from xran_packet_info import struct__packet_stats