### PR TITLE
Matt/ngap codelets

### DIFF
--- a/codelets/make.sh
+++ b/codelets/make.sh
@@ -15,6 +15,7 @@ Help()
    echo "Syntax: make [-d <directory>|-i <image_tag>|-o <extra_option>]"
    echo "options:"
    echo "[-d]   Run make in <directory> subfolder."
+   echo "[-i]   <image-tag>."
    echo "-o     Add extra options to make (can be repeated multiple times)."
    echo
 }

--- a/codelets/ngap/Makefile
+++ b/codelets/ngap/Makefile
@@ -1,0 +1,8 @@
+PROTO_AND_SCHEMA := \
+	ngap^ngap_procedure_started \
+	ngap^ngap_procedure_completed \
+	ngap^ngap_reset
+	 
+include ../Makefile.defs
+include ../Makefile.common
+

--- a/codelets/ngap/ngap.proto
+++ b/codelets/ngap/ngap.proto
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+syntax = "proto2";
+
+message ngap_ctx {
+    required uint32 cucp_ue_index = 1;
+    optional uint32 ran_ue_id = 2;
+    optional uint32 amf_ue_id = 3;
+
+}
+
+message ngap_procedure_started {
+    required uint64 timestamp = 1;
+    required ngap_ctx ue_ctx = 2;
+    required uint32 procedure = 3;
+}
+ 
+ message ngap_procedure_completed {
+    required uint64 timestamp = 1;
+    required ngap_ctx ue_ctx = 2;
+    required uint32 procedure = 3;
+    required uint32 success = 4;
+}
+
+message ngap_reset {
+    required uint64 timestamp = 1;
+    optional ngap_ctx ue_ctx = 2;
+    required uint32 procedure = 3;
+}

--- a/codelets/ngap/ngap.yaml
+++ b/codelets/ngap/ngap.yaml
@@ -13,7 +13,7 @@ codelet_descriptor:
       - name: output_map
         forward_destination: DestinationUDP
         serde:
-          file_path: ${JBPF_CODELETS}/ngap/ngap:ngap_procedure_started.so
+          file_path: ${JBPF_CODELETS}/ngap/ngap:ngap_procedure_started_serializer.so
           protobuf:
             package_path: ${JBPF_CODELETS}/ngap/ngap.pb
             msg_name: ngap_procedure_started
@@ -26,7 +26,7 @@ codelet_descriptor:
       - name: output_map
         forward_destination: DestinationUDP
         serde:
-          file_path: ${JBPF_CODELETS}/ngap/ngap:ngap_procedure_completed.so
+          file_path: ${JBPF_CODELETS}/ngap/ngap:ngap_procedure_completed_serializer.so
           protobuf:
             package_path: ${JBPF_CODELETS}/ngap/ngap.pb
             msg_name: ngap_procedure_completed
@@ -39,7 +39,7 @@ codelet_descriptor:
       - name: output_map
         forward_destination: DestinationUDP
         serde:
-          file_path: ${JBPF_CODELETS}/ngap/ngap:ngap_reset.so
+          file_path: ${JBPF_CODELETS}/ngap/ngap:ngap_reset_serializer.so
           protobuf:
             package_path: ${JBPF_CODELETS}/ngap/ngap.pb
             msg_name: ngap_reset

--- a/codelets/ngap/ngap.yaml
+++ b/codelets/ngap/ngap.yaml
@@ -1,0 +1,45 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+codeletset_id: ngap
+
+codelet_descriptor:
+
+  - codelet_name: ngap_procedure_started
+    codelet_path: ${JBPF_CODELETS}/ngap/ngap_procedure_started.o
+    hook_name: ngap_procedure_started
+    priority: 1
+    out_io_channel:
+      - name: output_map
+        forward_destination: DestinationUDP
+        serde:
+          file_path: ${JBPF_CODELETS}/ngap/ngap:ngap_procedure_started.so
+          protobuf:
+            package_path: ${JBPF_CODELETS}/ngap/ngap.pb
+            msg_name: ngap_procedure_started
+
+  - codelet_name: ngap_procedure_completed
+    codelet_path: ${JBPF_CODELETS}/ngap/ngap_procedure_completed.o
+    hook_name: ngap_procedure_completed
+    priority: 1
+    out_io_channel:
+      - name: output_map
+        forward_destination: DestinationUDP
+        serde:
+          file_path: ${JBPF_CODELETS}/ngap/ngap:ngap_procedure_completed.so
+          protobuf:
+            package_path: ${JBPF_CODELETS}/ngap/ngap.pb
+            msg_name: ngap_procedure_completed
+
+  - codelet_name: ngap_reset
+    codelet_path: ${JBPF_CODELETS}/ngap/ngap_reset.o
+    hook_name: ngap_reset
+    priority: 1
+    out_io_channel:
+      - name: output_map
+        forward_destination: DestinationUDP
+        serde:
+          file_path: ${JBPF_CODELETS}/ngap/ngap:ngap_reset.so
+          protobuf:
+            package_path: ${JBPF_CODELETS}/ngap/ngap.pb
+            msg_name: ngap_reset

--- a/codelets/ngap/ngap_procedure_completed.cpp
+++ b/codelets/ngap/ngap_procedure_completed.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include <linux/bpf.h>
+
+#include "jbpf_srsran_contexts.h"
+
+#include "ngap.pb.h"
+
+#include "../utils/misc_utils.h"
+
+
+#define SEC(NAME) __attribute__((section(NAME), used))
+
+#include "jbpf_defs.h"
+#include "jbpf_helper.h"
+
+#define MAX_NUM_UE (32)
+
+jbpf_ringbuf_map(output_map, ngap_procedure_completed, 256);
+
+struct jbpf_load_map_def SEC("maps") output_map_tmp = {
+  .type = JBPF_MAP_TYPE_ARRAY,
+  .key_size = sizeof(int),
+  .value_size = sizeof(ngap_procedure_completed),
+  .max_entries = 1,
+};
+
+
+//#define DEBUG_PRINT
+
+extern "C" SEC("jbpf_srsran_generic")
+uint64_t jbpf_main(void* state)
+{
+    int zero_index=0;
+    struct jbpf_ran_generic_ctx *ctx = (jbpf_ran_generic_ctx *)state;
+    
+    const jbpf_ngap_ctx_info& ngap_ctx = *reinterpret_cast<const jbpf_ngap_ctx_info*>(ctx->data);
+
+    // Ensure the object is within valid bounds
+    if (reinterpret_cast<const uint8_t*>(&ngap_ctx) + sizeof(jbpf_ngap_ctx_info) > reinterpret_cast<const uint8_t*>(ctx->data_end)) {
+        return JBPF_CODELET_FAILURE;  // Out-of-bounds access
+    }
+
+    ngap_procedure_completed *out = (ngap_procedure_completed *)jbpf_map_lookup_elem(&output_map_tmp, &zero_index);
+    if (!out)
+        return JBPF_CODELET_FAILURE;
+
+    out->timestamp = jbpf_time_get_ns();
+    out->ue_ctx.cucp_ue_index = ngap_ctx.cucp_ue_index;
+    if (ngap_ctx.ran_ue_ngap_id_set) {
+        out->ue_ctx.ran_ue_id = ngap_ctx.ran_ue_ngap_id;
+    }
+    if (ngap_ctx.amf_ue_ngap_id_set) {
+        out->ue_ctx.amf_ue_id = ngap_ctx.amf_ue_ngap_id;
+    }
+    out->procedure = ctx->srs_meta_data1 & 0xffffffff;
+    out->success = ctx->srs_meta_data1 >> 32;
+
+    int ret = jbpf_ringbuf_output(&output_map, (void *)out, sizeof(ngap_procedure_completed));
+    jbpf_map_clear(&output_map_tmp);
+    if (ret < 0) {
+#ifdef DEBUG_PRINT
+        jbpf_printf_debug("ngap_procedure_completed: Failure: jbpf_ringbuf_output\n");
+#endif
+        return JBPF_CODELET_FAILURE;
+    }
+
+    return JBPF_CODELET_SUCCESS;
+}

--- a/codelets/ngap/ngap_procedure_completed.cpp
+++ b/codelets/ngap/ngap_procedure_completed.cpp
@@ -50,9 +50,11 @@ uint64_t jbpf_main(void* state)
     out->ue_ctx.cucp_ue_index = ngap_ctx.cucp_ue_index;
     if (ngap_ctx.ran_ue_ngap_id_set) {
         out->ue_ctx.ran_ue_id = ngap_ctx.ran_ue_ngap_id;
+        out->ue_ctx.has_ran_ue_id = true;
     }
     if (ngap_ctx.amf_ue_ngap_id_set) {
         out->ue_ctx.amf_ue_id = ngap_ctx.amf_ue_ngap_id;
+        out->ue_ctx.has_amf_ue_id = true;
     }
     out->procedure = ctx->srs_meta_data1 & 0xffffffff;
     out->success = ctx->srs_meta_data1 >> 32;

--- a/codelets/ngap/ngap_procedure_started.cpp
+++ b/codelets/ngap/ngap_procedure_started.cpp
@@ -50,9 +50,11 @@ uint64_t jbpf_main(void* state)
     out->ue_ctx.cucp_ue_index = ngap_ctx.cucp_ue_index;
     if (ngap_ctx.ran_ue_ngap_id_set) {
         out->ue_ctx.ran_ue_id = ngap_ctx.ran_ue_ngap_id;
+        out->ue_ctx.has_ran_ue_id = true;
     }
     if (ngap_ctx.amf_ue_ngap_id_set) {
         out->ue_ctx.amf_ue_id = ngap_ctx.amf_ue_ngap_id;
+        out->ue_ctx.has_amf_ue_id = true;
     }
     out->procedure = ctx->srs_meta_data1 & 0xffffffff;
 

--- a/codelets/ngap/ngap_procedure_started.cpp
+++ b/codelets/ngap/ngap_procedure_started.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include <linux/bpf.h>
+
+#include "jbpf_srsran_contexts.h"
+
+#include "ngap.pb.h"
+
+#include "../utils/misc_utils.h"
+
+
+#define SEC(NAME) __attribute__((section(NAME), used))
+
+#include "jbpf_defs.h"
+#include "jbpf_helper.h"
+
+#define MAX_NUM_UE (32)
+
+jbpf_ringbuf_map(output_map, ngap_procedure_started, 256);
+
+struct jbpf_load_map_def SEC("maps") output_map_tmp = {
+  .type = JBPF_MAP_TYPE_ARRAY,
+  .key_size = sizeof(int),
+  .value_size = sizeof(ngap_procedure_started),
+  .max_entries = 1,
+};
+
+
+//#define DEBUG_PRINT
+
+extern "C" SEC("jbpf_srsran_generic")
+uint64_t jbpf_main(void* state)
+{
+    int zero_index=0;
+    struct jbpf_ran_generic_ctx *ctx = (jbpf_ran_generic_ctx *)state;
+    
+    const jbpf_ngap_ctx_info& ngap_ctx = *reinterpret_cast<const jbpf_ngap_ctx_info*>(ctx->data);
+
+    // Ensure the object is within valid bounds
+    if (reinterpret_cast<const uint8_t*>(&ngap_ctx) + sizeof(jbpf_ngap_ctx_info) > reinterpret_cast<const uint8_t*>(ctx->data_end)) {
+        return JBPF_CODELET_FAILURE;  // Out-of-bounds access
+    }
+
+    ngap_procedure_started *out = (ngap_procedure_started *)jbpf_map_lookup_elem(&output_map_tmp, &zero_index);
+    if (!out)
+        return JBPF_CODELET_FAILURE;
+
+    out->timestamp = jbpf_time_get_ns();
+    out->ue_ctx.cucp_ue_index = ngap_ctx.cucp_ue_index;
+    if (ngap_ctx.ran_ue_ngap_id_set) {
+        out->ue_ctx.ran_ue_id = ngap_ctx.ran_ue_ngap_id;
+    }
+    if (ngap_ctx.amf_ue_ngap_id_set) {
+        out->ue_ctx.amf_ue_id = ngap_ctx.amf_ue_ngap_id;
+    }
+    out->procedure = ctx->srs_meta_data1 & 0xffffffff;
+
+    int ret = jbpf_ringbuf_output(&output_map, (void *)out, sizeof(ngap_procedure_started));
+    jbpf_map_clear(&output_map_tmp);
+    if (ret < 0) {
+#ifdef DEBUG_PRINT
+        jbpf_printf_debug("ngap_procedure_started: Failure: jbpf_ringbuf_output\n");
+#endif
+        return JBPF_CODELET_FAILURE;
+    }
+
+    return JBPF_CODELET_SUCCESS;
+}

--- a/codelets/ngap/ngap_reset.cpp
+++ b/codelets/ngap/ngap_reset.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include <linux/bpf.h>
+
+#include "jbpf_srsran_contexts.h"
+
+#include "ngap.pb.h"
+
+#include "../utils/misc_utils.h"
+
+
+#define SEC(NAME) __attribute__((section(NAME), used))
+
+#include "jbpf_defs.h"
+#include "jbpf_helper.h"
+
+#define MAX_NUM_UE (32)
+
+jbpf_ringbuf_map(output_map, ngap_reset, 256);
+
+struct jbpf_load_map_def SEC("maps") output_map_tmp = {
+  .type = JBPF_MAP_TYPE_ARRAY,
+  .key_size = sizeof(int),
+  .value_size = sizeof(ngap_reset),
+  .max_entries = 1,
+};
+
+
+//#define DEBUG_PRINT
+
+extern "C" SEC("jbpf_srsran_generic")
+uint64_t jbpf_main(void* state)
+{
+    int zero_index=0;
+    struct jbpf_ran_generic_ctx *ctx = (jbpf_ran_generic_ctx *)state;
+    
+    const jbpf_ngap_ctx_info& ngap_ctx = *reinterpret_cast<const jbpf_ngap_ctx_info*>(ctx->data);
+
+    // Ensure the object is within valid bounds
+    if (reinterpret_cast<const uint8_t*>(&ngap_ctx) + sizeof(jbpf_ngap_ctx_info) > reinterpret_cast<const uint8_t*>(ctx->data_end)) {
+        return JBPF_CODELET_FAILURE;  // Out-of-bounds access
+    }
+
+    ngap_reset *out = (ngap_reset *)jbpf_map_lookup_elem(&output_map_tmp, &zero_index);
+    if (!out)
+        return JBPF_CODELET_FAILURE;
+
+    out->timestamp = jbpf_time_get_ns();
+
+    if ((ngap_ctx.ran_ue_ngap_id_set) || (ngap_ctx.amf_ue_ngap_id_set)) {
+        if (ngap_ctx.ran_ue_ngap_id_set) {
+            out->ue_ctx.ran_ue_id = ngap_ctx.ran_ue_ngap_id;
+        }
+        if (ngap_ctx.amf_ue_ngap_id_set) {
+            out->ue_ctx.amf_ue_id = ngap_ctx.amf_ue_ngap_id;
+        }
+    }
+
+    int ret = jbpf_ringbuf_output(&output_map, (void *)out, sizeof(ngap_reset));
+    jbpf_map_clear(&output_map_tmp);
+    if (ret < 0) {
+#ifdef DEBUG_PRINT
+        jbpf_printf_debug("ngap_reset: Failure: jbpf_ringbuf_output\n");
+#endif
+        return JBPF_CODELET_FAILURE;
+    }
+
+    return JBPF_CODELET_SUCCESS;
+}

--- a/codelets/ngap/ngap_reset.cpp
+++ b/codelets/ngap/ngap_reset.cpp
@@ -51,9 +51,11 @@ uint64_t jbpf_main(void* state)
     if ((ngap_ctx.ran_ue_ngap_id_set) || (ngap_ctx.amf_ue_ngap_id_set)) {
         if (ngap_ctx.ran_ue_ngap_id_set) {
             out->ue_ctx.ran_ue_id = ngap_ctx.ran_ue_ngap_id;
+             out->ue_ctx.has_ran_ue_id = true;
         }
         if (ngap_ctx.amf_ue_ngap_id_set) {
             out->ue_ctx.amf_ue_id = ngap_ctx.amf_ue_ngap_id;
+            out->ue_ctx.has_amf_ue_id = true;
         }
     }
 

--- a/containers/Docker/SRS-jbpf-sdk.Dockerfile
+++ b/containers/Docker/SRS-jbpf-sdk.Dockerfile
@@ -2,6 +2,7 @@
 # docker build -t ghcr.io/microsoft/jrtc-apps/srs-jbpf-proxy:latest -f SRS-jbpf-proxy.Dockerfile .
 # docker push ghcr.io/microsoft/jrtc-apps/srs-jbpf-proxy:latest
 
+ARG BASE_IMAGE_TAG=latest
 ARG SRS_JBPF_IMAGE_TAG=latest
 ARG JBPF_PROTOBUF_BUILDER_IMAGE=jbpf_protobuf_cli       
 ARG JBPF_PROTOBUF_BUILDER_IMAGE_TAG=latest
@@ -9,7 +10,7 @@ ARG JBPF_PROTOBUF_BUILDER_IMAGE_TAG=latest
 FROM ${JBPF_PROTOBUF_BUILDER_IMAGE}:${JBPF_PROTOBUF_BUILDER_IMAGE_TAG} AS jbpf_protobuf_builder
 FROM ghcr.io/microsoft/jrtc-apps/srs-jbpf:${SRS_JBPF_IMAGE_TAG} AS srsran
 
-FROM mcr.microsoft.com/azurelinux/base/core:3.0
+FROM ghcr.io/microsoft/jrtc-apps/base/srs:${BASE_IMAGE_TAG}
 
 LABEL org.opencontainers.image.source="https://github.com/microsoft/jrtc-apps"
 LABEL org.opencontainers.image.authors="Microsoft Corporation"
@@ -34,7 +35,7 @@ RUN echo "*** Installing relevant jbpf_protobuf binaries"
 COPY --from=jbpf_protobuf_builder /jbpf-protobuf/3p/nanopb /nanopb
 COPY --from=jbpf_protobuf_builder jbpf-protobuf/out/bin/jbpf_protobuf_cli /usr/local/bin/jbpf_protobuf_cli
 
-RUN tdnf install -y build-essential make python3-pip
+RUN tdnf install -y gcc gcc-c++ make python3 python3-pip
 RUN pip install ctypesgen
 RUN python3 -m pip install -r /nanopb/requirements.txt
 

--- a/containers/Docker/build_srs_jbpf_sdk.sh
+++ b/containers/Docker/build_srs_jbpf_sdk.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+BASE_IMAGE_TAG=latest
 IMAGE_TAG=latest
 
 Usage()
@@ -7,6 +8,7 @@ Usage()
    # Display Help
    echo "Build srsRan=Jbpf base image"
    echo "options:"
+   echo "[-b]    Optional base image tag.  Default='latest'"
    echo "[-s]    Optional srsRan image tag.  Default='latest'"
    echo
 }
@@ -14,6 +16,8 @@ Usage()
 # Get the options
 while getopts "s:c" option; do
 	case $option in
+		b) # Set image tag
+			BASE_IMAGE_TAG="$OPTARG";;
 		s) # Set image tag
 			IMAGE_TAG="$OPTARG";;
 		c) # Set image tag
@@ -45,6 +49,7 @@ popd > /dev/null
 
 
 docker build $CACHE_FLAG \
+  	--build-arg BASE_IMAGE_TAG=${BASE_IMAGE_TAG} \
     --build-arg SRS_JBPF_IMAGE_TAG=${IMAGE_TAG} \
     --build-arg JBPF_PROTOBUF_BUILDER_IMAGE=jbpf_protobuf_cli \
     --build-arg JBPF_PROTOBUF_BUILDER_IMAGE_TAG=latest \

--- a/jrtc_apps/dashboard/dashboard.py
+++ b/jrtc_apps/dashboard/dashboard.py
@@ -21,7 +21,7 @@ from jrtc_app import *
 
 
 include_ue_contexts = True
-include_perf = False #True
+include_perf = True
 include_rrc = True
 include_ngap = True
 include_pdcp = True

--- a/jrtc_apps/dashboard/dashboard.py
+++ b/jrtc_apps/dashboard/dashboard.py
@@ -175,7 +175,8 @@ class JsonUDPServer:
             while self.running:
                 try:
                     data, addr = self.sock.recvfrom(1024)
-                    self.json_handler_func(data.decode())
+                    if len(data) > 0:
+                        self.json_handler_func(data.decode())
                 except Exception as e:
                     print(f"JsonUDPServer: udp_server: error: {e}", flush=True)
         finally:
@@ -2142,6 +2143,8 @@ def jrtc_start_app(capsule):
 
     # run the app - This is blocking until the app exists
     jrtc_app_run(state.app)
+
+    json_udp_server.stop()
 
     # clean up app resources
     jrtc_app_destroy(state.app)

--- a/jrtc_apps/dashboard/deployment.yaml
+++ b/jrtc_apps/dashboard/deployment.yaml
@@ -39,6 +39,8 @@ app:
       - ${JBPF_CODELETS}/rrc/rrc_ue_update_context.py
       - ${JBPF_CODELETS}/rrc/rrc_ue_update_id.py
 
+      - ${JBPF_CODELETS}/ngap/ngap.py
+
       - ${JBPF_CODELETS}/fapi_dl_conf/fapi_gnb_dl_config_stats.py
       - ${JBPF_CODELETS}/fapi_ul_conf/fapi_gnb_ul_config_stats.py
       - ${JBPF_CODELETS}/fapi_ul_crc/fapi_gnb_crc_stats.py
@@ -70,6 +72,9 @@ jbpf:
 
     - device: 1
       config: ${JBPF_CODELETS}/rrc/rrc.yaml 
+
+    - device: 1
+      config: ${JBPF_CODELETS}/ngap/ngap.yaml 
 
     - device: 1
       config: ${JBPF_CODELETS}/fapi_dl_conf/fapi_gnb_dl_config_stats.yaml

--- a/jrtc_apps/dashboard/simple.yaml
+++ b/jrtc_apps/dashboard/simple.yaml
@@ -34,6 +34,9 @@ jbpf:
       config: ${JBPF_CODELETS}/rrc/rrc.yaml 
 
     - device: 1
+      config: ${JBPF_CODELETS}/ngap/ngap.yaml 
+
+    - device: 1
       config: ${JBPF_CODELETS}/fapi_dl_conf/fapi_gnb_dl_config_stats.yaml
 
     - device: 1

--- a/jrtc_apps/libs/la_logger.py
+++ b/jrtc_apps/libs/la_logger.py
@@ -60,7 +60,7 @@ class LaLogger:
         if ((len(self.batch) + 1) > self.cfg.batch_max_num_packets) or (
             (total_batch_len + len_msg) > self.cfg.batch_max_num_bytes
         ):
-            self.flush_batch()
+            self.flush_batch(batch_len_exceeded=((total_batch_len + len_msg) > self.cfg.batch_max_num_bytes))
 
         if len(self.batch) == 0:
             self.batch_start_time = dt.datetime.now(dt.timezone.utc)
@@ -88,6 +88,7 @@ class LaLogger:
 
     ############################################
     def LA_build_signature(self, date, content_length, method, content_type, resource):
+
         x_headers = "x-ms-date:" + date
         string_to_hash = (
             method
@@ -109,16 +110,21 @@ class LaLogger:
         return authorization
 
     ############################################
-    def post_it(self, uri, data, headers):
-        response = requests.post(uri, data=data, headers=headers)
-        if not (response.status_code >= 200 and response.status_code <= 299):
-            if self.dbg:
+    def post_it(self, uri, data, headers) -> bool:
+        try:
+            response = requests.post(uri, data=data, headers=headers)
+            if not (response.status_code >= 200 and response.status_code <= 299):
                 print(
-                    f"**** Log Analytics error, response code: {response.status_code}"
+                    f"**** Log Analytics error, response code: {response.status_code}, flush=True"
                 )
+                return False
+            return True
+        except Exception as e:
+            print(f"**** Log Analytics exception: {e}", flush=True)
+            return False
 
     ############################################
-    def post_data(self, data):
+    def post_data(self, data) -> bool:
     
         method = "POST"
         content_type = "application/json"
@@ -142,29 +148,45 @@ class LaLogger:
             "Log-Type": self.cfg.log_type,
             "x-ms-date": rfc1123date,
         }
-
-        self.post_it(uri, data, headers)
+        return self.post_it(uri, data, headers)
 
     ############################################
-    def flush_batch(self):
+    def flush_batch(self, batch_len_exceeded: bool = False):
         if self.batch_payload_bytes == 0:
             return
 
         if self.dbg:
             print(
-                f"LaLogger():flush_batch: len batch -> {len(self.batch)} bytes={self.batch_payload_bytes} "
+                f"LaLogger():flush_batch: len batch -> {len(self.batch)} bytes={self.batch_payload_bytes} ", flush=True
             )
 
         # create batch message
         s = "[" + ",".join(self.batch) + "]"
 
-        self.post_data(s)
+        result = self.post_data(s)
 
-        # reset batch
-        self.batch = []
-        self.batch_payload_bytes = 0
+        if result is True:
+            # successfully sent, reset batch
 
-        self.batch_start_time = None
+            # reset batch
+            self.batch = []
+            self.batch_payload_bytes = 0
+            self.batch_start_time = None
+
+        else:
+
+            # failed to send
+            
+            # if batch_len_exceeded is True then drop the batch
+            # else keep the batch for next time
+            if batch_len_exceeded:
+                print("**** Log Analytics error:   batch length exceeded, dropping batch", flush=True)
+                self.batch = []
+                self.batch_payload_bytes = 0
+                self.batch_start_time = None
+            else:
+                print("**** Log Analytics error:   keeping batch for next transmission", flush=True)
+
 
     ############################################
     def __close(self):

--- a/jrtc_apps/load.sh
+++ b/jrtc_apps/load.sh
@@ -14,6 +14,7 @@ Help()
    echo
    echo "Syntax: $0 -y <deployment-yaml>"
    echo "options:"
+   echo "[-s]   Optional SDK image tag.  Default='latest'"
    echo "-y     App yaml file with path"
    echo
 }
@@ -21,8 +22,10 @@ Help()
 DEPLOYMENT_YAML=""
 
 # Get the options
-while getopts "y:" option; do
+while getopts "s:y:" option; do
 	case $option in
+		s) # Set image tag
+			SDK_IMAGE_TAG="$OPTARG";;
 		y) 
 			DEPLOYMENT_YAML="$OPTARG";;
 		\?) # Invalid option
@@ -31,6 +34,8 @@ while getopts "y:" option; do
 			exit;;
 	esac
 done
+
+echo SDK_IMAGE_TAG $SDK_IMAGE_TAG
 
 if [[ -z "$DEPLOYMENT_YAML" || ! -f "$DEPLOYMENT_YAML" ]]; then
     echo "Error: DEPLOYMENT_YAML is either not set or the file does not exist."

--- a/jrtc_apps/unload.sh
+++ b/jrtc_apps/unload.sh
@@ -14,6 +14,7 @@ Help()
    echo
    echo "Syntax: $0 -y <deployment-yaml>"
    echo "options:"
+   echo "[-s]   Optional SDK image tag.  Default='latest'"
    echo "-y     App yaml file with path"
    echo
 }
@@ -21,8 +22,10 @@ Help()
 DEPLOYMENT_YAML=""
 
 # Get the options
-while getopts "y:" option; do
+while getopts "s:y:" option; do
 	case $option in
+		s) # Set image tag
+			SDK_IMAGE_TAG="$OPTARG";;
 		y) 
 			DEPLOYMENT_YAML="$OPTARG";;
 		\?) # Invalid option
@@ -31,6 +34,8 @@ while getopts "y:" option; do
 			exit;;
 	esac
 done
+
+echo SDK_IMAGE_TAG $SDK_IMAGE_TAG
 
 if [[ -z "$DEPLOYMENT_YAML" || ! -f "$DEPLOYMENT_YAML" ]]; then
     echo "Error: DEPLOYMENT_YAML is either not set or the file does not exist."


### PR DESCRIPTION
Add NGAP codelets.

These were integrated into jrtc_apps/dashboard/dashboard.py.
Also, in gthe dashboard.py, the NGAP identifiers are now used as the correlation data to map RAN and AMF information.  So, now RAN UE-specific stats such as RLC, PDCP, FAPI etc.. also include the IMSI that they relate to.,
