### PR TITLE
Fix stats range issue

### DIFF
--- a/codelets/mac/mac_helpers.h
+++ b/codelets/mac/mac_helpers.h
@@ -6,47 +6,9 @@
 
 #include "jbpf_srsran_contexts.h"
 
+#include "../utils/stats_utils.h"
+
 #define MAX_NUM_UE (32)
-
-
-#define MAC_STATS_INIT(__dest)       \
-    do {                             \
-        __dest.count = 0;            \
-        __dest.total = 0;            \
-        __dest.min = UINT32_MAX;     \
-        __dest.max = 0;              \
-    } while (0)
-
-
-
-#define MAC_STATS_UPDATE(__dest, __src)  \
-    do {                                 \
-        __dest.count++;                  \
-        if (__src < __dest.min) {        \
-             __dest.min = __src;         \
-        }                                \
-        if (__src > __dest.max) {        \
-            __dest.max = __src;          \
-        }                                \
-        __dest.total += __src;           \
-    } while (0)
-
-
-
-
-#define MAC_TRAFFIC_STATS_INIT(__dest)   \
-    do {                                 \
-        __dest.count = 0;                \
-        __dest.total = 0;                \
-    } while (0)
-
-#define MAC_TRAFFIC_STATS_UPDATE(__dest, __v)   \
-    do {                                        \
-        __dest.count++;                         \
-        __dest.total += __v;                    \
-    } while (0)
-
-
 
 
 #define MAC_HARQ_STATS_INIT(__dest, __cell_id, __rnti, __du_ue_index)  \
@@ -54,17 +16,17 @@
         __dest.cell_id = __cell_id;                                               \
         __dest.rnti = __rnti;                                                     \
         __dest.du_ue_index = __du_ue_index;                                       \
-        MAC_STATS_INIT(__dest.cons_retx);                                         \
-        MAC_STATS_INIT(__dest.mcs);                                               \
+        STATS_INIT(__dest.cons_retx);                                         \
+        STATS_INIT(__dest.mcs);                                               \
         __dest.perHarqTypeStats[JBPF_HARQ_EVENT_TX].count = 0;                          \
         __dest.perHarqTypeStats[JBPF_HARQ_EVENT_TX].has_cqi = false;                    \
-        MAC_TRAFFIC_STATS_INIT(__dest.perHarqTypeStats[JBPF_HARQ_EVENT_TX].tbs_bytes);  \
+        TRAFFIC_STATS_INIT(__dest.perHarqTypeStats[JBPF_HARQ_EVENT_TX].tbs_bytes);  \
         __dest.perHarqTypeStats[JBPF_HARQ_EVENT_RETX].count = 0;                        \
         __dest.perHarqTypeStats[JBPF_HARQ_EVENT_RETX].has_cqi = false;                  \
-        MAC_TRAFFIC_STATS_INIT(__dest.perHarqTypeStats[JBPF_HARQ_EVENT_RETX].tbs_bytes);\
+        TRAFFIC_STATS_INIT(__dest.perHarqTypeStats[JBPF_HARQ_EVENT_RETX].tbs_bytes);\
         __dest.perHarqTypeStats[JBPF_HARQ_EVENT_FAILURE].count = 0;                     \
         __dest.perHarqTypeStats[JBPF_HARQ_EVENT_FAILURE].has_cqi = false;               \
-        MAC_TRAFFIC_STATS_INIT(__dest.perHarqTypeStats[JBPF_HARQ_EVENT_FAILURE].tbs_bytes); \
+        TRAFFIC_STATS_INIT(__dest.perHarqTypeStats[JBPF_HARQ_EVENT_FAILURE].tbs_bytes); \
     } while (0) 
 
 #define MAC_HARQ_STATS_INIT_UL MAC_HARQ_STATS_INIT_DL
@@ -73,11 +35,11 @@
     do {                                                                        \
         MAC_HARQ_STATS_INIT(__dest, __cell_id, __rnti, __du_ue_index);            \
         __dest.perHarqTypeStats[JBPF_HARQ_EVENT_TX].has_cqi = true;                     \
-        MAC_STATS_INIT(__dest.perHarqTypeStats[JBPF_HARQ_EVENT_TX].cqi);                    \
+        STATS_INIT(__dest.perHarqTypeStats[JBPF_HARQ_EVENT_TX].cqi);                    \
         __dest.perHarqTypeStats[JBPF_HARQ_EVENT_RETX].has_cqi = true;                   \
-        MAC_STATS_INIT(__dest.perHarqTypeStats[JBPF_HARQ_EVENT_RETX].cqi);                  \
+        STATS_INIT(__dest.perHarqTypeStats[JBPF_HARQ_EVENT_RETX].cqi);                  \
         __dest.perHarqTypeStats[JBPF_HARQ_EVENT_FAILURE].has_cqi = true;                \
-        MAC_STATS_INIT(__dest.perHarqTypeStats[JBPF_HARQ_EVENT_FAILURE].cqi);               \
+        STATS_INIT(__dest.perHarqTypeStats[JBPF_HARQ_EVENT_FAILURE].cqi);               \
     } while (0) 
 
 

--- a/codelets/mac/mac_sched_crc_stats.proto
+++ b/codelets/mac/mac_sched_crc_stats.proto
@@ -11,11 +11,11 @@ message t_crc_stats {
    required uint32 cnt_tx = 4;
    repeated uint32 retx_hist = 5;
    required uint32 harq_failure = 6;
-   required uint32 min_sinr = 7;
+   required int32 min_sinr = 7;
    required int32 min_rsrp = 8;
-   required uint32 max_sinr = 9;
+   required int32 max_sinr = 9;
    required int32 max_rsrp = 10;
-   required uint32 sum_sinr = 11;
+   required int32 sum_sinr = 11;
    required int32 sum_rsrp = 12;
    required uint32 cnt_sinr = 13;
    required uint32 cnt_rsrp = 14;

--- a/codelets/mac/mac_sched_harq_stats.proto
+++ b/codelets/mac/mac_sched_harq_stats.proto
@@ -5,14 +5,14 @@ syntax = "proto2";
 
 message t_harq_stat_item {
    required uint32 count = 1;
-   required uint32 total = 2;
+   required uint64 total = 2;
    required uint32 min = 3;
    required uint32 max = 4;
 }
 
 message t_harq_stat_traffic_item {
    required uint32 count = 1;
-   required uint32 total = 2;
+   required uint64 total = 2;
 }
 
 message t_harq_type_stats {

--- a/codelets/mac/mac_sched_uci_pdu_stats.cpp
+++ b/codelets/mac/mac_sched_uci_pdu_stats.cpp
@@ -17,7 +17,7 @@
 #include "jbpf_defs.h"
 #include "jbpf_helper.h"
 #include "jbpf_helper_utils.h"
-
+#include "../utils/stats_utils.h"
 
 
 struct jbpf_load_map_def SEC("maps") uci_not_empty = {
@@ -39,19 +39,6 @@ struct jbpf_load_map_def SEC("maps") stats_map_uci = {
 DEFINE_PROTOHASH_32(uci_hash, MAX_NUM_UE);
 
 
-
-
-#define STATS_UPDATE(dest, src)   \
-    do {                                  \
-        dest.count++;                     \
-        if (src < dest.min) {             \
-            dest.min = src;               \
-        }                                 \
-        if (src > dest.max) {             \
-            dest.max = src;               \
-        }                                 \
-        dest.total += src;                \
-    } while (0)
 
 
 //#define DEBUG_PRINT

--- a/codelets/mac/mac_sched_ue_deletion.cpp
+++ b/codelets/mac/mac_sched_ue_deletion.cpp
@@ -124,13 +124,13 @@ uint64_t jbpf_main(void* state)
         crc_out->stats[ind % MAX_NUM_UE].retx_hist[i] = 0;
     }
     crc_out->stats[ind % MAX_NUM_UE].harq_failure = 0;
-    crc_out->stats[ind % MAX_NUM_UE].min_sinr = UINT32_MAX;
-    crc_out->stats[ind % MAX_NUM_UE].min_rsrp = UINT32_MAX;
-    crc_out->stats[ind % MAX_NUM_UE].max_sinr = 0;
-    crc_out->stats[ind % MAX_NUM_UE].max_rsrp = INT32_MIN;
+    crc_out->stats[ind % MAX_NUM_UE].min_sinr = INT16_MAX;
+    crc_out->stats[ind % MAX_NUM_UE].max_sinr = INT16_MIN;
     crc_out->stats[ind % MAX_NUM_UE].sum_sinr = 0;
-    crc_out->stats[ind % MAX_NUM_UE].sum_rsrp = 0;
     crc_out->stats[ind % MAX_NUM_UE].cnt_sinr = 0;
+    crc_out->stats[ind % MAX_NUM_UE].min_rsrp = UINT32_MAX;
+    crc_out->stats[ind % MAX_NUM_UE].max_rsrp = 0;
+    crc_out->stats[ind % MAX_NUM_UE].sum_rsrp = 0;
     crc_out->stats[ind % MAX_NUM_UE].cnt_rsrp = 0;
 
     ind = JBPF_PROTOHASH_LOOKUP_ELEM_32(uci_out, stats, uci_hash, ctx->du_ue_index, new_val);

--- a/codelets/pdcp/pdcp_dl_discard.cpp
+++ b/codelets/pdcp/pdcp_dl_discard.cpp
@@ -90,8 +90,8 @@ uint64_t jbpf_main(void* state)
     // update window_info
     const jbpf_queue_info_t* queue_info = &pdcp_ctx.window_info;
     if (queue_info->used) {
-        PDCP_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_pkts, queue_info->num_pkts);
-        PDCP_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_bytes, queue_info->num_bytes);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_pkts, queue_info->num_pkts);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_bytes, queue_info->num_bytes);
         out->stats[ind % MAX_NUM_UE_RB].has_pdu_window_pkts = true;
         out->stats[ind % MAX_NUM_UE_RB].has_pdu_window_bytes = true;
     }

--- a/codelets/pdcp/pdcp_dl_new_sdu.cpp
+++ b/codelets/pdcp/pdcp_dl_new_sdu.cpp
@@ -10,6 +10,7 @@
 
 #include "../utils/misc_utils.h"
 #include "../utils/hashmap_utils.h"
+#include "../utils/stats_utils.h"
 
 
 #define SEC(NAME) __attribute__((section(NAME), used))
@@ -89,14 +90,14 @@ uint64_t jbpf_main(void* state)
 
     const jbpf_queue_info_t* queue_info = &pdcp_ctx.window_info;
     if (queue_info->used) {
-        PDCP_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_pkts, queue_info->num_pkts);
-        PDCP_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_bytes, queue_info->num_bytes);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_pkts, queue_info->num_pkts);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_bytes, queue_info->num_bytes);
         out->stats[ind % MAX_NUM_UE_RB].has_pdu_window_pkts = true;
         out->stats[ind % MAX_NUM_UE_RB].has_pdu_window_bytes = true;
     }
 
     // update sdu_new_bytes
-    PDCP_TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_new_bytes, sdu_length);
+    TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_new_bytes, sdu_length);
 
     *not_empty_stats = 1;
 

--- a/codelets/pdcp/pdcp_dl_stats.proto
+++ b/codelets/pdcp/pdcp_dl_stats.proto
@@ -5,14 +5,14 @@ syntax = "proto2";
 
 message t_dl_stats_item {
    required uint32 count = 1;
-   required uint32 total = 2;
+   required uint64 total = 2;
    required uint32 min = 3;
    required uint32 max = 4;
 }
 
 message t_dl_traffic_stats_item {
    required uint32 count = 1;
-   required uint32 total = 2;
+   required uint64 total = 2;
 }
 
 message t_dl_stats {

--- a/codelets/pdcp/pdcp_dl_tx_control_pdu.cpp
+++ b/codelets/pdcp/pdcp_dl_tx_control_pdu.cpp
@@ -10,6 +10,7 @@
 
 #include "../utils/misc_utils.h"
 #include "../utils/hashmap_utils.h"
+#include "../utils/stats_utils.h"
 
 
 #define SEC(NAME) __attribute__((section(NAME), used))
@@ -90,15 +91,15 @@ uint64_t jbpf_main(void* state)
     // update window_info
     const jbpf_queue_info_t* queue_info = &pdcp_ctx.window_info;
     if (queue_info->used) {
-        PDCP_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_pkts, queue_info->num_pkts);
-        PDCP_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_bytes, queue_info->num_bytes);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_pkts, queue_info->num_pkts);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_bytes, queue_info->num_bytes);
         out->stats[ind % MAX_NUM_UE_RB].has_pdu_window_pkts = true;
         out->stats[ind % MAX_NUM_UE_RB].has_pdu_window_bytes = true;
     }
 
     ///////////////////////////////////////////////////////
     // update control_pdu_tx_bytes
-    PDCP_TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].control_pdu_tx_bytes, pdu_length);
+    TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].control_pdu_tx_bytes, pdu_length);
 
     *not_empty_stats = 1;
 

--- a/codelets/pdcp/pdcp_dl_tx_data_pdu.cpp
+++ b/codelets/pdcp/pdcp_dl_tx_data_pdu.cpp
@@ -10,6 +10,7 @@
 
 #include "../utils/misc_utils.h"
 #include "../utils/hashmap_utils.h"
+#include "../utils/stats_utils.h"
 
 
 #define SEC(NAME) __attribute__((section(NAME), used))
@@ -96,22 +97,22 @@ uint64_t jbpf_main(void* state)
     // update window_info
     const jbpf_queue_info_t* queue_info = &pdcp_ctx.window_info;
     if (queue_info->used) {
-        PDCP_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_pkts, queue_info->num_pkts);
-        PDCP_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_bytes, queue_info->num_bytes);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_pkts, queue_info->num_pkts);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_bytes, queue_info->num_bytes);
     }
 
     ///////////////////////////////////////////////////////
     // update data_pdu_tx_bytes / data_pdu_retx_bytes
     if (is_retx) {
-        PDCP_TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].data_pdu_retx_bytes, pdu_length);
+        TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].data_pdu_retx_bytes, pdu_length);
     } else {
-        PDCP_TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].data_pdu_tx_bytes, pdu_length);
+        TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].data_pdu_tx_bytes, pdu_length);
     }
 
     ///////////////////////////////////////////////////////
     // update sdu_tx_latency
     if (latency_set) {
-        PDCP_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_tx_latency, latency_ns);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_tx_latency, latency_ns);
         out->stats[ind % MAX_NUM_UE_RB].has_sdu_tx_latency = true;
     }
 

--- a/codelets/pdcp/pdcp_helpers.h
+++ b/codelets/pdcp/pdcp_helpers.h
@@ -4,6 +4,7 @@
 #ifndef JRTC_PDCP_HELPERS_H
 #define JRTC_PDCP_HELPERS_H
 
+#include "../utils/stats_utils.h"
 
 #define MAX_NUM_UE_RB (256)
 
@@ -13,55 +14,20 @@
 
 
 
-#define PDCP_STATS_INIT(dest)   \
-    do {                           \
-        dest.count = 0;            \
-        dest.total = 0;            \
-        dest.min = UINT32_MAX;     \
-        dest.max = 0;              \
-    } while (0)
-
-#define PDCP_STATS_UPDATE(dest, src)   \
-    do {                                  \
-        dest.count++;                     \
-        if (src < dest.min) {             \
-            dest.min = src;               \
-        }                                 \
-        if (src > dest.max) {             \
-            dest.max = src;               \
-        }                                 \
-        dest.total += src;                \
-    } while (0)
-
-
-
-#define PDCP_TRAFFIC_STATS_INIT(dest)   \
-    do {                           \
-        dest.count = 0;            \
-        dest.total = 0;            \
-    } while (0)
-
-#define PDCP_TRAFFIC_STATS_UPDATE(dest, v)   \
-    do {                           \
-        dest.count++;            \
-        dest.total += v;            \
-    } while (0)
-
-
 #define PDCP_DL_STATS_INIT(dest, __cu_ue_index, __is_srb, __rb_id, __rlc_mode)  \
     do {                                                                        \
         dest.cu_ue_index = __cu_ue_index;                                       \
         dest.is_srb = __is_srb;                                                 \
         dest.rb_id = __rb_id;                                                   \
         dest.rlc_mode = PDCP_RLCMODE_2_JBPF_RLCMODE(__rlc_mode);                \
-        PDCP_TRAFFIC_STATS_INIT(dest.sdu_new_bytes);                            \
+        TRAFFIC_STATS_INIT(dest.sdu_new_bytes);                            \
         dest.sdu_discarded = 0;                                                 \
-        PDCP_TRAFFIC_STATS_INIT(dest.data_pdu_tx_bytes);                        \
-        PDCP_TRAFFIC_STATS_INIT(dest.data_pdu_retx_bytes);                      \
-        PDCP_TRAFFIC_STATS_INIT(dest.control_pdu_tx_bytes);                     \
-        PDCP_STATS_INIT(dest.pdu_window_pkts);                                  \
-        PDCP_STATS_INIT(dest.pdu_window_bytes);                                 \
-        PDCP_STATS_INIT(dest.sdu_tx_latency);                                   \
+        TRAFFIC_STATS_INIT(dest.data_pdu_tx_bytes);                        \
+        TRAFFIC_STATS_INIT(dest.data_pdu_retx_bytes);                      \
+        TRAFFIC_STATS_INIT(dest.control_pdu_tx_bytes);                     \
+        STATS_INIT(dest.pdu_window_pkts);                                  \
+        STATS_INIT(dest.pdu_window_bytes);                                 \
+        STATS_INIT(dest.sdu_tx_latency);                                   \
     } while (0) 
 
 
@@ -72,11 +38,11 @@
         dest.is_srb = __is_srb;                                         \
         dest.rb_id = __rb_id;                                           \
         dest.rlc_mode = PDCP_RLCMODE_2_JBPF_RLCMODE(__rlc_mode);        \
-        PDCP_TRAFFIC_STATS_INIT(dest.sdu_delivered_bytes);              \
-        PDCP_TRAFFIC_STATS_INIT(dest.rx_data_pdu_bytes);                \
-        PDCP_TRAFFIC_STATS_INIT(dest.rx_control_pdu_bytes);             \
-        PDCP_STATS_INIT(dest.pdu_window_pkts);                          \
-        PDCP_STATS_INIT(dest.pdu_window_bytes);                         \
+        TRAFFIC_STATS_INIT(dest.sdu_delivered_bytes);              \
+        TRAFFIC_STATS_INIT(dest.rx_data_pdu_bytes);                \
+        TRAFFIC_STATS_INIT(dest.rx_control_pdu_bytes);             \
+        STATS_INIT(dest.pdu_window_pkts);                          \
+        STATS_INIT(dest.pdu_window_bytes);                         \
     } while (0)
 
 

--- a/codelets/pdcp/pdcp_ul_deliver_sdu.cpp
+++ b/codelets/pdcp/pdcp_ul_deliver_sdu.cpp
@@ -10,6 +10,7 @@
 
 #include "../utils/misc_utils.h"
 #include "../utils/hashmap_utils.h"
+#include "../utils/stats_utils.h"
 
 
 #define SEC(NAME) __attribute__((section(NAME), used))
@@ -87,12 +88,12 @@ uint64_t jbpf_main(void* state)
     ///////////////////////////////////////////////// 
     // window info
     const jbpf_queue_info_t* queue_info = &pdcp_ctx.window_info;
-    PDCP_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_pkts, queue_info->num_pkts);
-    PDCP_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_bytes, queue_info->num_bytes);
+    STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_pkts, queue_info->num_pkts);
+    STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_bytes, queue_info->num_bytes);
 
     ///////////////////////////////////////////////// 
     // sdu_delivered_bytes
-    PDCP_TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_delivered_bytes, sdu_length);
+    TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_delivered_bytes, sdu_length);
 
     *not_empty_stats = 1;
 

--- a/codelets/pdcp/pdcp_ul_rx_control_pdu.cpp
+++ b/codelets/pdcp/pdcp_ul_rx_control_pdu.cpp
@@ -10,6 +10,7 @@
 
 #include "../utils/misc_utils.h"
 #include "../utils/hashmap_utils.h"
+#include "../utils/stats_utils.h"
 
 
 #define SEC(NAME) __attribute__((section(NAME), used))
@@ -86,12 +87,12 @@ uint64_t jbpf_main(void* state)
     ///////////////////////////////////////////////// 
     // window info
     const jbpf_queue_info_t* queue_info = &pdcp_ctx.window_info;
-    PDCP_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_pkts, queue_info->num_pkts);
-    PDCP_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_bytes, queue_info->num_bytes);
+    STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_pkts, queue_info->num_pkts);
+    STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_bytes, queue_info->num_bytes);
 
     ///////////////////////////////////////////////// 
     // rx_control_pdu_bytes
-    PDCP_TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].rx_control_pdu_bytes, pdu_length);
+    TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].rx_control_pdu_bytes, pdu_length);
 
     *not_empty_stats = 1;
 

--- a/codelets/pdcp/pdcp_ul_rx_data_pdu.cpp
+++ b/codelets/pdcp/pdcp_ul_rx_data_pdu.cpp
@@ -10,6 +10,7 @@
 
 #include "../utils/misc_utils.h"
 #include "../utils/hashmap_utils.h"
+#include "../utils/stats_utils.h"
 
 
 #define SEC(NAME) __attribute__((section(NAME), used))
@@ -88,12 +89,12 @@ uint64_t jbpf_main(void* state)
     ///////////////////////////////////////////////// 
     // window info
     const jbpf_queue_info_t* queue_info = &pdcp_ctx.window_info;
-    PDCP_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_pkts, queue_info->num_pkts);
-    PDCP_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_bytes, queue_info->num_bytes);
+    STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_pkts, queue_info->num_pkts);
+    STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_window_bytes, queue_info->num_bytes);
 
     ///////////////////////////////////////////////// 
     // rx_data_pdu_bytes
-    PDCP_TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].rx_data_pdu_bytes, pdu_length);
+    TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].rx_data_pdu_bytes, pdu_length);
 
     *not_empty_stats = 1;
 

--- a/codelets/pdcp/pdcp_ul_stats.proto
+++ b/codelets/pdcp/pdcp_ul_stats.proto
@@ -5,14 +5,14 @@ syntax = "proto2";
 
 message t_ul_stats_item {
    required uint32 count = 1;
-   required uint32 total = 2;
+   required uint64 total = 2;
    required uint32 min = 3;
    required uint32 max = 4;
 }
 
 message t_ul_traffic_stats_item {
    required uint32 count = 1;
-   required uint32 total = 2;
+   required uint64 total = 2;
 }
 
 message t_ul_stats {

--- a/codelets/rlc/rlc_dl_am_tx_pdu_retx_count.cpp
+++ b/codelets/rlc/rlc_dl_am_tx_pdu_retx_count.cpp
@@ -10,6 +10,7 @@
 
 #include "../utils/misc_utils.h"
 #include "../utils/hashmap_utils.h"
+#include "../utils/stats_utils.h"
 
 
 #define SEC(NAME) __attribute__((section(NAME), used))
@@ -100,8 +101,8 @@ uint64_t jbpf_main(void* state)
         queue_info = &rlc_ctx.u.tm_tx.sdu_queue_info;
     }  
     if (queue_info) {
-        RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_queue_pkts, queue_info->num_pkts);
-        RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_queue_bytes, queue_info->num_bytes);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_queue_pkts, queue_info->num_pkts);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_queue_bytes, queue_info->num_bytes);
     }
 
     /////////////////////////////////////////////
@@ -110,14 +111,14 @@ uint64_t jbpf_main(void* state)
 
         /////////////////////////////////////////////
         // pdu_retx_count
-        RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_retx_count, retx_count);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_retx_count, retx_count);
 
         /////////////////////////////////////////////
         // update pdu_window
         const jbpf_queue_info_t* queue_info = &rlc_ctx.u.am_tx.window_info;
         if (queue_info->used) {
-            RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_pkts, queue_info->num_pkts);
-            RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_bytes, queue_info->num_bytes);
+            STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_pkts, queue_info->num_pkts);
+            STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_bytes, queue_info->num_bytes);
         }
     }	
 

--- a/codelets/rlc/rlc_dl_deletion.cpp
+++ b/codelets/rlc/rlc_dl_deletion.cpp
@@ -11,6 +11,7 @@
 #include "../utils/hashmap_utils.h"
 
 
+
 #define SEC(NAME) __attribute__((section(NAME), used))
 
 #include "jbpf_defs.h"

--- a/codelets/rlc/rlc_dl_new_sdu.cpp
+++ b/codelets/rlc/rlc_dl_new_sdu.cpp
@@ -10,6 +10,7 @@
 
 #include "../utils/misc_utils.h"
 #include "../utils/hashmap_utils.h"
+#include "../utils/stats_utils.h"
 
 
 #define SEC(NAME) __attribute__((section(NAME), used))
@@ -98,13 +99,13 @@ uint64_t jbpf_main(void* state)
         queue_info = &rlc_ctx.u.tm_tx.sdu_queue_info;
     }  
     if (queue_info) {
-        RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_queue_pkts, queue_info->num_pkts);
-        RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_queue_bytes, queue_info->num_bytes);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_queue_pkts, queue_info->num_pkts);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_queue_bytes, queue_info->num_bytes);
     }
     
     /////////////////////////////////////////////
     // update sdu_new_bytes
-    RLC_TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_new_bytes, sdu_length);
+    TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_new_bytes, sdu_length);
 
     if (out->stats[ind % MAX_NUM_UE_RB].has_am) {
 
@@ -112,8 +113,8 @@ uint64_t jbpf_main(void* state)
         // update pdu_window
         const jbpf_queue_info_t* queue_info = &rlc_ctx.u.am_tx.window_info;
         if (queue_info->used) {
-            RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_pkts, queue_info->num_pkts);
-            RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_bytes, queue_info->num_bytes);
+            STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_pkts, queue_info->num_pkts);
+            STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_bytes, queue_info->num_bytes);
         }
     }
 

--- a/codelets/rlc/rlc_dl_stats.proto
+++ b/codelets/rlc/rlc_dl_stats.proto
@@ -5,14 +5,14 @@ syntax = "proto2";
 
 message t_dl_stats_item {
    required uint32 count = 1;
-   required uint32 total = 2;
+   required uint64 total = 2;
    required uint32 min = 3;
    required uint32 max = 4;
 }
 
 message t_dl_traffic_stats_item {
    required uint32 count = 1;
-   required uint32 total = 2;
+   required uint64 total = 2;
 }
 
 message t_dl_stats_am {

--- a/codelets/rlc/rlc_dl_tx_pdu.cpp
+++ b/codelets/rlc/rlc_dl_tx_pdu.cpp
@@ -10,6 +10,7 @@
 
 #include "../utils/misc_utils.h"
 #include "../utils/hashmap_utils.h"
+#include "../utils/stats_utils.h"
 
 
 #define SEC(NAME) __attribute__((section(NAME), used))
@@ -98,14 +99,14 @@ uint64_t jbpf_main(void* state)
         queue_info = &rlc_ctx.u.tm_tx.sdu_queue_info;
     }  
     if (queue_info) {
-        RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_queue_pkts, queue_info->num_pkts);
-        RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_queue_bytes, queue_info->num_bytes);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_queue_pkts, queue_info->num_pkts);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_queue_bytes, queue_info->num_bytes);
     }
 
     /////////////////////////////////////////////
     // pdu_tx_bytes
     if (pdu_type == JBPF_RLC_PDUTYPE_DATA) {
-        RLC_TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_tx_bytes, pdu_len);
+        TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_tx_bytes, pdu_len);
     }
 
     /////////////////////////////////////////////
@@ -115,21 +116,21 @@ uint64_t jbpf_main(void* state)
         /////////////////////////////////////////////
         // pdu_retx_bytes
         if (pdu_type == JBPF_RLC_PDUTYPE_DATA_RETX) {
-            RLC_TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_retx_bytes, pdu_len);
+            TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_retx_bytes, pdu_len);
         }
 
         /////////////////////////////////////////////
         // pdu_status_bytes
         if (pdu_type == JBPF_RLC_PDUTYPE_STATUS) {
-            RLC_TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_status_bytes, pdu_len);
+            TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_status_bytes, pdu_len);
         }
 
         /////////////////////////////////////////////
         // update pdu_window
         const jbpf_queue_info_t* queue_info = &rlc_ctx.u.am_tx.window_info;
         if (queue_info->used) {
-            RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_pkts, queue_info->num_pkts);
-            RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_bytes, queue_info->num_bytes);
+            STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_pkts, queue_info->num_pkts);
+            STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_bytes, queue_info->num_bytes);
         } 
     }	
 

--- a/codelets/rlc/rlc_dl_tx_sdu_completed.cpp
+++ b/codelets/rlc/rlc_dl_tx_sdu_completed.cpp
@@ -10,6 +10,7 @@
 
 #include "../utils/misc_utils.h"
 #include "../utils/hashmap_utils.h"
+#include "../utils/stats_utils.h"
 
 
 #define SEC(NAME) __attribute__((section(NAME), used))
@@ -99,13 +100,13 @@ uint64_t jbpf_main(void* state)
         queue_info = &rlc_ctx.u.tm_tx.sdu_queue_info;
     }  
     if (queue_info) {
-        RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_queue_pkts, queue_info->num_pkts);
-        RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_queue_bytes, queue_info->num_bytes);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_queue_pkts, queue_info->num_pkts);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_queue_bytes, queue_info->num_bytes);
     }
 
     /////////////////////////////////////////////
     // sdu_tx_completed
-    RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_tx_completed, latency_ns);
+    STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_tx_completed, latency_ns);
 
     /////////////////////////////////////////////
     // AM fields
@@ -115,8 +116,8 @@ uint64_t jbpf_main(void* state)
         // update pdu_window
         const jbpf_queue_info_t* queue_info = &rlc_ctx.u.am_tx.window_info;
         if (queue_info->used) {
-            RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_pkts, queue_info->num_pkts);
-            RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_bytes, queue_info->num_bytes);
+            STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_pkts, queue_info->num_pkts);
+            STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_bytes, queue_info->num_bytes);
         } 
     }	
 

--- a/codelets/rlc/rlc_dl_tx_sdu_delivered.cpp
+++ b/codelets/rlc/rlc_dl_tx_sdu_delivered.cpp
@@ -10,6 +10,7 @@
 
 #include "../utils/misc_utils.h"
 #include "../utils/hashmap_utils.h"
+#include "../utils/stats_utils.h"
 
 
 #define SEC(NAME) __attribute__((section(NAME), used))
@@ -99,13 +100,13 @@ uint64_t jbpf_main(void* state)
         queue_info = &rlc_ctx.u.tm_tx.sdu_queue_info;
     }  
     if (queue_info) {
-        RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_queue_pkts, queue_info->num_pkts);
-        RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_queue_bytes, queue_info->num_bytes);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_queue_pkts, queue_info->num_pkts);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_queue_bytes, queue_info->num_bytes);
     }
 
     /////////////////////////////////////////////
     // sdu_tx_delivered
-    RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_tx_delivered, latency_ns);
+    STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_tx_delivered, latency_ns);
 
     /////////////////////////////////////////////
     // AM fields
@@ -115,8 +116,8 @@ uint64_t jbpf_main(void* state)
         // update pdu_window
         const jbpf_queue_info_t* queue_info = &rlc_ctx.u.am_tx.window_info;
         if (queue_info->used) {
-            RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_pkts, queue_info->num_pkts);
-            RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_bytes, queue_info->num_bytes);
+            STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_pkts, queue_info->num_pkts);
+            STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_bytes, queue_info->num_bytes);
         } 
     }	
 

--- a/codelets/rlc/rlc_dl_tx_sdu_started.cpp
+++ b/codelets/rlc/rlc_dl_tx_sdu_started.cpp
@@ -10,6 +10,7 @@
 
 #include "../utils/misc_utils.h"
 #include "../utils/hashmap_utils.h"
+#include "../utils/stats_utils.h"
 
 
 #define SEC(NAME) __attribute__((section(NAME), used))
@@ -99,13 +100,13 @@ uint64_t jbpf_main(void* state)
         queue_info = &rlc_ctx.u.tm_tx.sdu_queue_info;
     }  
     if (queue_info) {
-        RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_queue_pkts, queue_info->num_pkts);
-        RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_queue_bytes, queue_info->num_bytes);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_queue_pkts, queue_info->num_pkts);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_queue_bytes, queue_info->num_bytes);
     }
 
     /////////////////////////////////////////////
     // sdu_tx_started
-    RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_tx_started, latency_ns);
+    STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_tx_started, latency_ns);
 
     /////////////////////////////////////////////
     // AM fields
@@ -115,8 +116,8 @@ uint64_t jbpf_main(void* state)
         // update pdu_window
         const jbpf_queue_info_t* queue_info = &rlc_ctx.u.am_tx.window_info;
         if (queue_info->used) {
-            RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_pkts, queue_info->num_pkts);
-            RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_bytes, queue_info->num_bytes);
+            STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_pkts, queue_info->num_pkts);
+            STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_bytes, queue_info->num_bytes);
         } 
     }	
 

--- a/codelets/rlc/rlc_helpers.h
+++ b/codelets/rlc/rlc_helpers.h
@@ -4,43 +4,10 @@
 #ifndef JRTC_RLC_HELPERS_H
 #define JRTC_RLC_HELPERS_H
 
+#include "../utils/stats_utils.h"
+
+
 #define MAX_NUM_UE_RB (256)
-
-
-#define RLC_STATS_INIT(dest)   \
-    do {                           \
-        dest.count = 0;            \
-        dest.total = 0;            \
-        dest.min = UINT32_MAX;     \
-        dest.max = 0;              \
-    } while (0)
-
-#define RLC_STATS_UPDATE(dest, src)   \
-    do {                                  \
-        dest.count++;                     \
-        if (src < dest.min) {             \
-            dest.min = src;               \
-        }                                 \
-        if (src > dest.max) {             \
-            dest.max = src;               \
-        }                                 \
-        dest.total += src;                \
-    } while (0)
-
-
-
-#define RLC_TRAFFIC_STATS_INIT(dest)   \
-    do {                           \
-        dest.count = 0;            \
-        dest.total = 0;            \
-    } while (0)
-
-#define RLC_TRAFFIC_STATS_UPDATE(dest, v)   \
-    do {                           \
-        dest.count++;            \
-        dest.total += v;            \
-    } while (0)
-
 
 
 #define RLC_DL_STATS_INIT(dest, __du_ue_index, __is_srb, __rb_id, __rlc_mode)  \
@@ -49,20 +16,20 @@
         dest.is_srb = __is_srb;                                                \
         dest.rb_id = __rb_id;                                                  \
         dest.rlc_mode = __rlc_mode;                                            \
-        RLC_STATS_INIT(dest.sdu_queue_pkts);                                   \
-        RLC_STATS_INIT(dest.sdu_queue_bytes);                                  \
-        RLC_TRAFFIC_STATS_INIT(dest.sdu_new_bytes);                            \
-        RLC_TRAFFIC_STATS_INIT(dest.pdu_tx_bytes);                             \
-        RLC_STATS_INIT(dest.sdu_tx_started);                                   \
-        RLC_STATS_INIT(dest.sdu_tx_completed);                                 \
-        RLC_STATS_INIT(dest.sdu_tx_delivered);                                 \
+        STATS_INIT(dest.sdu_queue_pkts);                                   \
+        STATS_INIT(dest.sdu_queue_bytes);                                  \
+        TRAFFIC_STATS_INIT(dest.sdu_new_bytes);                            \
+        TRAFFIC_STATS_INIT(dest.pdu_tx_bytes);                             \
+        STATS_INIT(dest.sdu_tx_started);                                   \
+        STATS_INIT(dest.sdu_tx_completed);                                 \
+        STATS_INIT(dest.sdu_tx_delivered);                                 \
         dest.has_am = (rlc_ctx.rlc_mode == JBPF_RLC_MODE_AM);                  \
         if (dest.has_am) {                                                     \
-            RLC_TRAFFIC_STATS_INIT(dest.am.pdu_retx_bytes);                    \
-            RLC_TRAFFIC_STATS_INIT(dest.am.pdu_status_bytes);                  \
-            RLC_STATS_INIT(dest.am.pdu_retx_count);                            \
-            RLC_STATS_INIT(dest.am.pdu_window_pkts);                           \
-            RLC_STATS_INIT(dest.am.pdu_window_bytes);                          \
+            TRAFFIC_STATS_INIT(dest.am.pdu_retx_bytes);                    \
+            TRAFFIC_STATS_INIT(dest.am.pdu_status_bytes);                  \
+            STATS_INIT(dest.am.pdu_retx_count);                            \
+            STATS_INIT(dest.am.pdu_window_pkts);                           \
+            STATS_INIT(dest.am.pdu_window_bytes);                          \
         }                                                                      \
     } while (0)
 
@@ -73,16 +40,16 @@
         dest.is_srb = __is_srb;                                                \
         dest.rb_id = __rb_id;                                                  \
         dest.rlc_mode = __rlc_mode;                                            \
-        RLC_TRAFFIC_STATS_INIT(dest.pdu_bytes);                                \
-        RLC_TRAFFIC_STATS_INIT(dest.sdu_delivered_bytes);                      \
-        RLC_STATS_INIT(dest.sdu_delivered_latency);                            \
+        TRAFFIC_STATS_INIT(dest.pdu_bytes);                                \
+        TRAFFIC_STATS_INIT(dest.sdu_delivered_bytes);                      \
+        STATS_INIT(dest.sdu_delivered_latency);                            \
         dest.has_um = (rlc_ctx.rlc_mode == JBPF_RLC_MODE_UM);                  \
         if (dest.has_um) {                                                     \
-            RLC_STATS_INIT(dest.um.pdu_window_pkts);                           \
+            STATS_INIT(dest.um.pdu_window_pkts);                           \
         }                                                                      \
         dest.has_am = (rlc_ctx.rlc_mode == JBPF_RLC_MODE_AM);                  \
         if (dest.has_um) {                                                     \
-            RLC_STATS_INIT(dest.am.pdu_window_pkts);                           \
+            STATS_INIT(dest.am.pdu_window_pkts);                           \
         }                                                                      \
     } while (0)
 

--- a/codelets/rlc/rlc_ul_deliver_sdu.cpp
+++ b/codelets/rlc/rlc_ul_deliver_sdu.cpp
@@ -10,6 +10,7 @@
 
 #include "../utils/misc_utils.h"
 #include "../utils/hashmap_utils.h"
+#include "../utils/stats_utils.h"
 
 
 #define SEC(NAME) __attribute__((section(NAME), used))
@@ -90,22 +91,22 @@ uint64_t jbpf_main(void* state)
 
     /////////////////////////////////////////////
     // sdu_delivered_bytes
-    RLC_TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_delivered_bytes, sdu_length);
+    TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_delivered_bytes, sdu_length);
 
     /////////////////////////////////////////////
     // sdu_delivered_latency
-    RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_delivered_latency, latency_ns);
+    STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].sdu_delivered_latency, latency_ns);
 
     /////////////////////////////////////////////
     // UM
     if (out->stats[ind % MAX_NUM_UE_RB].has_um) {
-        RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].um.pdu_window_pkts, rlc_ctx.u.um_rx.window_num_pkts);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].um.pdu_window_pkts, rlc_ctx.u.um_rx.window_num_pkts);
     }	
 	
     /////////////////////////////////////////////
     // AM
     if (out->stats[ind % MAX_NUM_UE_RB].has_am) {
-        RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_pkts, rlc_ctx.u.am_rx.window_num_pkts);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_pkts, rlc_ctx.u.am_rx.window_num_pkts);
     }	
      
     *not_empty_stats = 1;

--- a/codelets/rlc/rlc_ul_rx_pdu.cpp
+++ b/codelets/rlc/rlc_ul_rx_pdu.cpp
@@ -10,6 +10,7 @@
 
 #include "../utils/misc_utils.h"
 #include "../utils/hashmap_utils.h"
+#include "../utils/stats_utils.h"
 
 
 #define SEC(NAME) __attribute__((section(NAME), used))
@@ -90,19 +91,19 @@ uint64_t jbpf_main(void* state)
     /////////////////////////////////////////////
     // pdu_bytes
     if (pdu_type == JBPF_RLC_PDUTYPE_DATA) {
-        RLC_TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_bytes, pdu_len);
+        TRAFFIC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].pdu_bytes, pdu_len);
     }
 
     /////////////////////////////////////////////
     // UM
     if (out->stats[ind % MAX_NUM_UE_RB].has_um) {
-        RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].um.pdu_window_pkts, rlc_ctx.u.um_rx.window_num_pkts);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].um.pdu_window_pkts, rlc_ctx.u.um_rx.window_num_pkts);
     }	
 	
     /////////////////////////////////////////////
     // AM
     if (out->stats[ind % MAX_NUM_UE_RB].has_am) {
-        RLC_STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_pkts, rlc_ctx.u.am_rx.window_num_pkts);
+        STATS_UPDATE(out->stats[ind % MAX_NUM_UE_RB].am.pdu_window_pkts, rlc_ctx.u.am_rx.window_num_pkts);
     }	
     
     *not_empty_stats = 1;

--- a/codelets/rlc/rlc_ul_stats.proto
+++ b/codelets/rlc/rlc_ul_stats.proto
@@ -5,14 +5,14 @@ syntax = "proto2";
 
 message t_ul_stats_item {
    required uint32 count = 1;
-   required uint32 total = 2;
+   required uint64 total = 2;
    required uint32 min = 3;
    required uint32 max = 4;
 }
 
 message t_ul_traffic_stats_item {
    required uint32 count = 1;
-   required uint32 total = 2;
+   required uint64 total = 2;
 }
 
 message t_ul_stats_um {

--- a/codelets/utils/stats_utils.h
+++ b/codelets/utils/stats_utils.h
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#ifndef JRTC_STATS_UTILS_H
+#define JRTC_STATS_UTILS_H
+
+#include "jbpf_srsran_contexts.h"
+
+#define MAX_NUM_UE (32)
+
+
+#define STATS_INIT(__dest)       \
+    do {                             \
+        __dest.count = 0;            \
+        __dest.total = 0;            \
+        __dest.min = UINT32_MAX;     \
+        __dest.max = 0;              \
+    } while (0)
+
+
+#define STATS_UPDATE(__dest, __src)  \
+    do {                                 \
+        __dest.count++;                  \
+        if (__src < __dest.min) {        \
+             __dest.min = __src;         \
+        }                                \
+        if (__src > __dest.max) {        \
+            __dest.max = __src;          \
+        }                                \
+        __dest.total += __src;           \
+    } while (0)
+
+
+#define TRAFFIC_STATS_INIT(__dest)   \
+    do {                                 \
+        __dest.count = 0;                \
+        __dest.total = 0;                \
+    } while (0)
+
+
+#define TRAFFIC_STATS_UPDATE(__dest, __v)   \
+    do {                                        \
+        __dest.count++;                         \
+        __dest.total += __v;                    \
+    } while (0)
+
+
+#endif // JRTC_STATS_UTILS_H

--- a/jrtc_apps/dashboard/dashboard.json
+++ b/jrtc_apps/dashboard/dashboard.json
@@ -40,7 +40,7 @@
               "durationMs": 86400000
             },
             "value": {
-              "durationMs": 14400000
+              "durationMs": 300000
             }
           }
         ],
@@ -651,27 +651,6 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let timeStart = todatetime({timeparameter:start});\r\nlet timeEnd = todatetime({timeparameter:end});\r\nlet duration = timeEnd - timeStart;\r\nlet maxPoints = 10000;  // Hard limit for visualization\r\nlet baseStep = case(\r\n    duration >= 7d, 15m,\r\n    duration >= 3d, 6m,     \r\n    duration >= 48h, 4m, \r\n    duration >= 24h, 2m,\r\n    duration >= 12h, 1m, \r\n    duration >= 4h, 30s,\r\n    duration >= 1h, 30s,\r\n    duration >= 15m, 20s,\r\n    20s  // Default step size\r\n);\r\nlet totalPoints = tolong(duration / baseStep);\r\nlet scaleFactor = ceiling(totalPoints * 1.0 / maxPoints);  // Ensure step scaling\r\nlet adjustedStep = baseStep * scaleFactor;\r\njrtc_dashboard_CL\r\n| where stream_id_s == \"dashboard\"\r\n| extend stream_payload_msg=todynamic(stream_payload_msg_s)  // Expand the array of stats_s into individual rows\r\n| extend stream_index_s = tostring(stream_payload_msg.stream_index)\r\n| where stream_index_s == \"MAC_SCHED_UCI_STATS\"\r\n| mv-expand stream_payload_msg.stats\r\n| extend stats_d = todynamic(stream_payload_msg_stats)\r\n| extend ueIndex = tostring(stats_d.ueid), timsi = tostring(stats_d.ue_ctx.tmsi), supi = tostring(stats_d.ue_ctx.core_amf_info.supi), isSRB = toint(stats_d.is_srb), rbID = tostring(stats_d.rb_id), avgHarqAck = todouble(stats_d.harq.ack), avgHarqNack = todouble(stats_d.harq.nack), timestamp = unixtime_nanoseconds_todatetime(tolong(stream_payload_msg.timestamp))\r\n| extend imsi = iff(not(isempty(supi)), substring(supi, 5), timsi)\r\n| where not(isempty(imsi)) // Only include UEs connected for a longer time\r\n| project imsi_rb = strcat(imsi, \"/\", rbID), avgErr = avgHarqNack / (avgHarqNack + avgHarqAck), timestamp\r\n| where timestamp >= timeStart and timestamp <= timeEnd\r\n| make-series avgErr=avg(avgErr*100) default=0 \r\n  on timestamp from timeStart to timeEnd step adjustedStep by imsi_rb\r\n| render timechart",
-              "size": 1,
-              "title": "Downlink loss rate at MAC level [%]",
-              "timeContextFromParameter": "timeparameter",
-              "queryType": 0,
-              "resourceType": "microsoft.operationalinsights/workspaces",
-              "chartSettings": {
-                "showMetrics": false,
-                "showLegend": true,
-                "ySettings": {
-                  "min": 0
-                }
-              }
-            },
-            "customWidth": "33",
-            "name": "query - 6 - Copy - Copy - Copy"
-          },
-          {
-            "type": 3,
-            "content": {
-              "version": "KqlItem/1.0",
               "query": "let timeStart = todatetime({timeparameter:start});\r\nlet timeEnd = todatetime({timeparameter:end});\r\nlet duration = timeEnd - timeStart;\r\nlet maxPoints = 10000;  // Hard limit for visualization\r\nlet baseStep = case(\r\n    duration >= 7d, 15m,\r\n    duration >= 3d, 8m,     \r\n    duration >= 48h, 4m, \r\n    duration >= 24h, 2m,\r\n    duration >= 12h, 1m, \r\n    duration >= 4h, 30s,\r\n    duration >= 1h, 30s,\r\n    duration >= 15m, 20s,\r\n    10s  // Default step size\r\n);\r\nlet totalPoints = tolong(duration / baseStep);\r\nlet scaleFactor = ceiling(totalPoints * 1.0 / maxPoints);  // Ensure step scaling\r\nlet adjustedStep = baseStep * scaleFactor;\r\njrtc_dashboard_CL\r\n| where stream_id_s == \"dashboard\"\r\n| extend stream_payload_msg=todynamic(stream_payload_msg_s)  // Expand the array of stats_s into individual rows\r\n| extend stream_index_s = tostring(stream_payload_msg.stream_index)\r\n| where stream_index_s == \"FAPI_DL_CONFIG\"\r\n| mv-expand stream_payload_msg.ues\r\n| extend ues = todynamic(stream_payload_msg_ues)\r\n| extend ueIndex = tostring(ues.ueid), timsi = tostring(ues.ue_ctx.tmsi), supi = tostring(ues.ue_ctx.core_amf_info.supi), l1PrbAvg = todouble(ues.l1_prb_avg), timestamp = unixtime_nanoseconds_todatetime(tolong(stream_payload_msg.timestamp))\r\n| extend imsi = iff(not(isempty(supi)), substring(supi, 5), timsi)\r\n| project timestamp, imsi, l1PrbAvg  // Select relevant columns\r\n| where timestamp >= timeStart and timestamp <= timeEnd\r\n| make-series l1PrbAvg=avg(l1PrbAvg) default=0 \r\n  on timestamp from timeStart to timeEnd step adjustedStep by imsi\r\n| render timechart\r\n",
               "size": 1,
               "title": "Average downlink spectrum utilization (in PRB) per user",
@@ -683,7 +662,7 @@
                 "showLegend": true
               }
             },
-            "customWidth": "25",
+            "customWidth": "33",
             "name": "query - 7"
           },
           {
@@ -701,7 +680,7 @@
                 "showLegend": true
               }
             },
-            "customWidth": "25",
+            "customWidth": "33",
             "name": "query - 7 - Copy"
           },
           {
@@ -719,7 +698,7 @@
                 "showLegend": true
               }
             },
-            "customWidth": "25",
+            "customWidth": "33",
             "name": "query - 7 - Copy - Copy"
           },
           {
@@ -737,7 +716,7 @@
                 "showLegend": true
               }
             },
-            "customWidth": "25",
+            "customWidth": "33",
             "name": "query - 7 - Copy - Copy - Copy - Copy"
           },
           {
@@ -835,7 +814,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let timeStart = todatetime({timeparameter:start});\r\nlet timeEnd = todatetime({timeparameter:end});\r\nlet duration = timeEnd - timeStart;\r\nlet maxPoints = 10000;  // Hard limit for visualization\r\nlet baseStep = case(\r\n    duration >= 7d, 15m,\r\n    duration >= 3d, 8m,     \r\n    duration >= 48h, 4m, \r\n    duration >= 24h, 2m,\r\n    duration >= 12h, 1m, \r\n    duration >= 4h, 30s,\r\n    duration >= 1h, 30s,\r\n    duration >= 15m, 20s,\r\n    20s  // Default step size\r\n);\r\nlet totalPoints = tolong(duration / baseStep);\r\nlet scaleFactor = ceiling(totalPoints * 1.0 / maxPoints);  // Ensure step scaling\r\nlet adjustedStep = baseStep * scaleFactor;\r\njrtc_dashboard_CL\r\n| where stream_id_s == \"dashboard\"\r\n| extend stream_payload_msg=todynamic(stream_payload_msg_s)  // Expand the array of stats_s into individual rows\r\n| extend stream_index_s = tostring(stream_payload_msg.stream_index)\r\n| where stream_index_s == \"MAC_SCHED_CRC_STATS\"\r\n| mv-expand stream_payload_msg.stats\r\n| extend stats_d = todynamic(stream_payload_msg_stats)\r\n| extend ueIndex = tostring(stats_d.ueid), timsi = tostring(stats_d.ue_ctx.tmsi), supi = tostring(stats_d.ue_ctx.core_amf_info.supi), maxSinr = todouble(stats_d.max_sinr), minSinr = todouble(stats_d.min_sinr), avgSinr = todouble(stats_d.avg_sinr), timestamp = unixtime_nanoseconds_todatetime(tolong(stream_payload_msg.timestamp))\r\n| extend imsi = iff(not(isempty(supi)), substring(supi, 5), timsi)\r\n| project timestamp, imsi, maxSinr, avgSinr  // Select relevant columns\r\n| where not(isempty(imsi)) // Only include UEs connected for a longer time\r\n| where timestamp >= timeStart and timestamp <= timeEnd and not(isempty(imsi))\r\n| make-series avgSinr=avg(avgSinr) default=0 \r\n  on timestamp from timeStart to timeEnd step adjustedStep by imsi\r\n| render timechart\r\n",
+              "query": "let timeStart = todatetime({timeparameter:start});\r\nlet timeEnd = todatetime({timeparameter:end});\r\nlet duration = timeEnd - timeStart;\r\nlet maxPoints = 10000;  // Hard limit for visualization\r\nlet baseStep = case(\r\n    duration >= 7d, 15m,\r\n    duration >= 3d, 8m,     \r\n    duration >= 48h, 4m, \r\n    duration >= 24h, 2m,\r\n    duration >= 12h, 1m, \r\n    duration >= 4h, 30s,\r\n    duration >= 1h, 30s,\r\n    duration >= 15m, 20s,\r\n    20s  // Default step size\r\n);\r\nlet totalPoints = tolong(duration / baseStep);\r\nlet scaleFactor = ceiling(totalPoints * 1.0 / maxPoints);  // Ensure step scaling\r\nlet adjustedStep = baseStep * scaleFactor;\r\njrtc_dashboard_CL\r\n| where stream_id_s == \"dashboard\"\r\n| extend stream_payload_msg=todynamic(stream_payload_msg_s)  // Expand the array of stats_s into individual rows\r\n| extend stream_index_s = tostring(stream_payload_msg.stream_index)\r\n| where stream_index_s == \"MAC_SCHED_CRC_STATS\"\r\n| mv-expand stream_payload_msg.stats\r\n| extend stats_d = todynamic(stream_payload_msg_stats)\r\n| extend ueIndex = tostring(stats_d.ueid), timsi = tostring(stats_d.ue_ctx.tmsi), supi = tostring(stats_d.ue_ctx.core_amf_info.supi), maxSinr = todouble(stats_d.max_sinr), minSinr = todouble(stats_d.min_sinr), avgSinr = todouble(stats_d.avg_sinr), timestamp = unixtime_nanoseconds_todatetime(tolong(stream_payload_msg.timestamp))\r\n| extend imsi = iff(not(isempty(supi)), substring(supi, 5), timsi)\r\n| project timestamp, imsi, maxSinr, avgSinr  // Select relevant columns\r\n| where not(isempty(imsi)) // Only include UEs connected for a longer time\r\n| where timestamp >= timeStart and timestamp <= timeEnd and not(isempty(imsi))\r\n| make-series avgSinr=avg(avgSinr) default=-65.0\r\n  on timestamp from timeStart to timeEnd step adjustedStep by imsi\r\n| render timechart\r\n",
               "size": 1,
               "title": "Avg uplink SINR [dB]",
               "timeContextFromParameter": "timeparameter",
@@ -844,8 +823,12 @@
               "chartSettings": {
                 "showMetrics": false,
                 "showLegend": true,
+                "customThresholdLine": "10",
+                "customThresholdLineStyle": 5,
                 "ySettings": {
-                  "min": 0
+                  "min": -66,
+                  "max": 66,
+                  "label": ""
                 }
               }
             },
@@ -856,19 +839,21 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let timeStart = todatetime({timeparameter:start});\r\nlet timeEnd = todatetime({timeparameter:end});\r\nlet duration = timeEnd - timeStart;\r\nlet maxPoints = 10000;  // Hard limit for visualization\r\nlet baseStep = case(\r\n    duration >= 7d, 15m,\r\n    duration >= 3d, 8m,     \r\n    duration >= 48h, 4m, \r\n    duration >= 24h, 2m,\r\n    duration >= 12h, 1m, \r\n    duration >= 4h, 20s,\r\n    duration >= 1h, 10s,\r\n    duration >= 15m, 5s,\r\n    1s  // Default step size\r\n);\r\nlet totalPoints = tolong(duration / baseStep);\r\nlet scaleFactor = ceiling(totalPoints * 1.0 / maxPoints);  // Ensure step scaling\r\nlet adjustedStep = baseStep * scaleFactor;\r\njrtc_dashboard_CL\r\n| where stream_id_s == \"dashboard\"\r\n| extend stream_payload_msg=todynamic(stream_payload_msg_s)  // Expand the array of stats_s into individual rows\r\n| extend stream_index_s = tostring(stream_payload_msg.stream_index)\r\n| where stream_index_s == \"MAC_SCHED_CRC_STATS\"\r\n| mv-expand stream_payload_msg.stats\r\n| extend stats_d = todynamic(stream_payload_msg_stats)\r\n| extend ueIndex = tostring(stats_d.ueid), timsi = tostring(stats_d.ue_ctx.tmsi), supi = tostring(stats_d.ue_ctx.core_amf_info.supi), loss = 1-todouble(stats_d.succ_rate), timestamp = unixtime_nanoseconds_todatetime(tolong(stream_payload_msg.timestamp))\r\n| extend imsi = iff(not(isempty(supi)), substring(supi, 5), timsi)\r\n| project timestamp, imsi, loss  // Select relevant columns\r\n| where not(isempty(imsi)) // Only include UEs connected for a longer time\r\n| where timestamp >= timeStart and timestamp <= timeEnd\r\n| make-series loss=avg(loss)*100 default=0 \r\n  on timestamp from timeStart to timeEnd step adjustedStep by imsi\r\n| render timechart\r\n",
+              "query": "\r\nlet timeStart = todatetime({timeparameter:start});\r\nlet timeEnd = todatetime({timeparameter:end});\r\nlet duration = timeEnd - timeStart;\r\nlet maxPoints = 10000;  // Hard limit for visualization\r\nlet baseStep = case(\r\n    duration >= 7d, 15m,\r\n    duration >= 3d, 8m,     \r\n    duration >= 48h, 4m, \r\n    duration >= 24h, 2m,\r\n    duration >= 12h, 1m, \r\n    duration >= 4h, 30s,\r\n    duration >= 1h, 30s,\r\n    duration >= 15m, 20s,\r\n    20s  // Default step size\r\n);\r\nlet totalPoints = tolong(duration / baseStep);\r\nlet scaleFactor = ceiling(totalPoints * 1.0 / maxPoints);  // Ensure step scaling\r\nlet adjustedStep = baseStep * scaleFactor;\r\njrtc_dashboard_CL\r\n| where stream_id_s == \"dashboard\"\r\n| extend stream_payload_msg=todynamic(stream_payload_msg_s)  // Expand the array of stats_s into individual rows\r\n| extend stream_index_s = tostring(stream_payload_msg.stream_index)\r\n| where stream_index_s == \"MAC_SCHED_CRC_STATS\"\r\n| mv-expand stream_payload_msg.stats\r\n| extend stats_d = todynamic(stream_payload_msg_stats)\r\n| extend ueIndex = tostring(stats_d.ueid), timsi = tostring(stats_d.ue_ctx.tmsi), supi = tostring(stats_d.ue_ctx.core_amf_info.supi), maxRsrp = todouble(stats_d.max_rsrp), minRsrp = todouble(stats_d.min_rsrp), avgRsrp = todouble(stats_d.avg_rsrp), timestamp = unixtime_nanoseconds_todatetime(tolong(stream_payload_msg.timestamp))\r\n| extend imsi = iff(not(isempty(supi)), substring(supi, 5), timsi)\r\n| project timestamp, imsi, maxRsrp, avgRsrp  // Select relevant columns\r\n| where not(isempty(imsi)) // Only include UEs connected for a longer time\r\n| where timestamp >= timeStart and timestamp <= timeEnd and not(isempty(imsi))\r\n| make-series avgRsrp=avg(avgRsrp) default=-128\r\n  on timestamp from timeStart to timeEnd step adjustedStep by imsi\r\n| render timechart\r\n\r\n",
               "size": 1,
-              "title": "Average uplink MAC packet loss rate [%]",
+              "title": "Avg uplink RSRP [dBm]",
               "timeContextFromParameter": "timeparameter",
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces",
               "chartSettings": {
                 "showMetrics": false,
-                "showLegend": true
+                "showLegend": true,
+                "customThresholdLine": "-80",
+                "customThresholdLineStyle": 5
               }
             },
             "customWidth": "33",
-            "name": "query - 5"
+            "name": "query - 4 - Copy"
           },
           {
             "type": 3,


### PR DESCRIPTION
The main issue this PR fixes is that some stats fields needed to be increase from uint32 to uint64.

As well as making this change, common macros were added for the MAC/RLC/PDCP codelets where 'stats' and 'traffic-stats' structures are used.
The common macros were added in new file codelets/utils/stats_utils.h.
