### PR TITLE
Issue 39 : Add CPU architecture optimizations and VOLK profiling support

### DIFF
--- a/.env
+++ b/.env
@@ -9,4 +9,4 @@ export DOCKER_CMD="docker"
 export USE_JRTC=1
 
 # SRSRAN INAGE TAGS.  Used for images in the variosu kubernetes yaml files, but also for building codelets
-export SRSRAN_IMAGE_TAG=srsran25.10-latest
+export SRSRAN_IMAGE_TAG=srsran25.10-2

--- a/containers/Docker/GRC.Dockerfile
+++ b/containers/Docker/GRC.Dockerfile
@@ -5,13 +5,20 @@ SHELL ["/bin/bash", "-c"]
 
 # Install GNU Radio runtime (no GUI)
 RUN apt-get clean -y && apt-get update -y
-RUN apt-get install -y gnuradio python3 python3-pip && \
+RUN apt-get install -y gnuradio python3 python3-pip libvolk2-bin && \
     apt-get clean
 
 # Create folders need for gnuradio
 RUN mkdir -p /root/.gnuradio /tmp/.gnuradio && chmod -R 777 /root/.gnuradio /tmp/.gnuradio
 RUN mkdir -p /root/.gnuradio/prefs
 RUN echo "DEFAULT" > /root/.gnuradio/prefs/vmcircbuf_default_factory
+
+# Pre-generate VOLK profile for the generic (portable) kernels to avoid
+# SIMD dispatch issues on CPUs different from the image build machine.
+# If volk_profile fails (e.g. no CPU match), fall back to generic config.
+RUN volk_profile || true
+RUN mkdir -p /etc/volk
+ENV VOLK_CONFIGPATH=/root/.volk
 
 # Copy your generated Python file
 COPY srs_grc/GRC_multi_ue_headless.py /app/GRC_multi_ue_headless.py

--- a/containers/Docker/SRS-jbpf-zmq.Dockerfile
+++ b/containers/Docker/SRS-jbpf-zmq.Dockerfile
@@ -1,4 +1,5 @@
 ARG SRS_JBPF_IMAGE_TAG=latest
+ARG MARCH=x86-64-v3
 
 # =============================
 # Stage 1: Build libzmq + czmq
@@ -34,6 +35,8 @@ RUN git clone --depth 1 https://github.com/zeromq/czmq.git && \
 # =============================
 FROM ghcr.io/microsoft/jrtc-apps/srs-jbpf:${SRS_JBPF_IMAGE_TAG}
 
+ARG MARCH
+
 # Copy only installed libs/binaries from builder
 COPY --from=builder /usr/local /usr/local
 
@@ -49,7 +52,7 @@ RUN ldconfig -p | grep zmq || true
 
 WORKDIR /src/build
 RUN rm -rf * /out
-RUN cmake .. -DENABLE_ZEROMQ=ON -DENABLE_JBPF=ON -DINITIALIZE_SUBMODULES=OFF -DCMAKE_C_FLAGS="-Wno-error=unused-variable"
+RUN cmake .. -DENABLE_ZEROMQ=ON -DENABLE_JBPF=ON -DINITIALIZE_SUBMODULES=OFF -DMARCH=${MARCH} -DCMAKE_C_FLAGS="-Wno-error=unused-variable"
 RUN make -j VERBOSE=1
 RUN make install
 

--- a/containers/Docker/SRS-jbpf.Dockerfile
+++ b/containers/Docker/SRS-jbpf.Dockerfile
@@ -5,16 +5,19 @@
 
 ARG LIB=dpdk
 ARG LIB_VERSION=23.11
+ARG MARCH=x86-64-v3
 
 ARG BASE_IMAGE_TAG=latest
 FROM ghcr.io/microsoft/jrtc-apps/base/srs:${BASE_IMAGE_TAG}
+
+ARG MARCH
 
 LABEL org.opencontainers.image.source="https://github.com/microsoft/jrtc-apps"
 LABEL org.opencontainers.image.authors="Microsoft Corporation"
 LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.description="SRSRAN with JBPF support"
 
-ADD srsRAN_Project /src 
+ADD srsRAN_Project /src
 
 ENV PKG_CONFIG_PATH=/opt/dpdk-23.11/build/meson-private:/usr/lib/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:$PKG_CONFIG_PATH
 
@@ -26,7 +29,7 @@ RUN mkdir build
 WORKDIR /src/build
 # Temporary fix for failing jbpf tests in RELEASE mode. To be removed when jbpf tests are fixed.
 #RUN cmake .. -DENABLE_DPDK=True -DENABLE_JBPF=ON -DINITIALIZE_SUBMODULES=OFF
-RUN cmake .. -DENABLE_DPDK=True -DENABLE_JBPF=ON -DINITIALIZE_SUBMODULES=OFF -DCMAKE_C_FLAGS="-Wno-error=unused-variable"
+RUN cmake .. -DENABLE_DPDK=True -DENABLE_JBPF=ON -DINITIALIZE_SUBMODULES=OFF -DMARCH=${MARCH} -DCMAKE_C_FLAGS="-Wno-error=unused-variable"
 RUN make -j VERBOSE=1
 RUN make install
 

--- a/containers/Docker/SRS-ue.Dockerfile
+++ b/containers/Docker/SRS-ue.Dockerfile
@@ -1,6 +1,9 @@
 ARG SRSRAN_IMAGE_TAG=latest
+ARG GCC_ARCH=x86-64-v3
 
 FROM ghcr.io/microsoft/jrtc-apps/srs-ue-base:${SRSRAN_IMAGE_TAG}
+
+ARG GCC_ARCH
 
 LABEL org.opencontainers.image.source="https://github.com/microsoft/jrtc-apps"
 LABEL org.opencontainers.image.authors="Microsoft Corporation"
@@ -11,7 +14,7 @@ LABEL org.opencontainers.image.description="SDK for SRSRAN with JBPF, built in Z
 WORKDIR /
 ADD srsRAN_4G /srsRAN_4G
 WORKDIR /srsRAN_4G/build
-RUN cmake ../ -DENABLE_RF_PLUGINS=OFF -DCMAKE_C_COMPILER=/usr/local/gcc-11/bin/gcc -DCMAKE_CXX_COMPILER=/usr/local/gcc-11/bin/g++ -DBOOST_ROOT=/usr/local
+RUN cmake ../ -DENABLE_RF_PLUGINS=OFF -DGCC_ARCH=${GCC_ARCH} -DCMAKE_C_COMPILER=/usr/local/gcc-11/bin/gcc -DCMAKE_CXX_COMPILER=/usr/local/gcc-11/bin/g++ -DBOOST_ROOT=/usr/local
 RUN make -j`nproc`
 RUN make install
 

--- a/containers/Docker/base.Dockerfile
+++ b/containers/Docker/base.Dockerfile
@@ -5,6 +5,8 @@
 
 FROM mcr.microsoft.com/azurelinux/base/core:3.0
 
+ARG DPDK_MACHINE=default
+
 COPY Scripts/mariner-extras.repo /etc/yum.repos.d
 RUN tdnf makecache
 
@@ -50,7 +52,7 @@ WORKDIR /opt
 RUN wget https://fast.dpdk.org/rel/dpdk-23.11.tar.xz
 RUN tar xvf dpdk-23.11.tar.xz dpdk-23.11
 WORKDIR /opt/dpdk-23.11
-RUN meson setup build
+RUN meson setup build -Dmachine=${DPDK_MACHINE}
 WORKDIR /opt/dpdk-23.11/build
 RUN ninja
 RUN meson install

--- a/containers/Docker/build_base.sh
+++ b/containers/Docker/build_base.sh
@@ -3,14 +3,17 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-BASE_IMAGE_TAG=latest
+CURRENT_DIR=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+source $(dirname $(dirname "$CURRENT_DIR"))/set_vars.sh
+
+BASE_IMAGE_TAG=$SRSRAN_IMAGE_TAG
 
 Usage()
 {
    # Display Help
    echo "Build srsRan base image"
    echo "options:"
-   echo "[-b]    Optional base image tag.  Default='latest'"
+   echo "[-b]    Optional base image tag.  Default='$SRSRAN_IMAGE_TAG'"
    echo
 }
 

--- a/containers/Docker/build_srs_jbpf.sh
+++ b/containers/Docker/build_srs_jbpf.sh
@@ -3,30 +3,35 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-BASE_IMAGE_TAG=latest
+MARCH=x86-64-v3
 CACHE_FLAG=
 
 CURRENT_DIR=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 source $(dirname $(dirname "$CURRENT_DIR"))/set_vars.sh
+
+BASE_IMAGE_TAG=$SRSRAN_IMAGE_TAG
 
 Usage()
 {
    # Display Help
    echo "Build srsRan image"
    echo "options:"
-   echo "[-b]    Optional base image tag.  Default='latest'"
+   echo "[-b]    Optional base image tag.  Default='$SRSRAN_IMAGE_TAG'"
    echo "[-s]    Optional image tag.  Default='$SRSRAN_IMAGE_TAG'"
+   echo "[-m]    Optional CPU march target.  Default='x86-64-v3' (AVX2)"
    echo "[-c]    Optional.  If included, '--no-cache- is added to the Docker build"
    echo
 }
 
 # Get the options
-while getopts "b:s:c" option; do
+while getopts "b:s:m:c" option; do
 	case $option in
 		b) # Set image tag
 			BASE_IMAGE_TAG="$OPTARG";;
 		s) # Set image tag
 			SRSRAN_IMAGE_TAG="$OPTARG";;
+		m) # Set CPU march target
+			MARCH="$OPTARG";;
 		c) # Set image tag
 			CACHE_FLAG="--no-cache";;
 		\?) # Invalid option
@@ -38,9 +43,24 @@ done
 
 echo BASE_IMAGE_TAG $BASE_IMAGE_TAG
 echo SRSRAN_IMAGE_TAG $SRSRAN_IMAGE_TAG
+echo MARCH $MARCH
+
+# Apply jbpf 3p patches (ck, mimalloc, ebpf-verifier) since INITIALIZE_SUBMODULES=OFF
+# skips init_and_patch_submodules.sh which requires git inside the container.
+JBPF_DIR=srsRAN_Project/external/jbpf
+if [ -f "$JBPF_DIR/patches/ck.patch" ]; then
+    echo "Applying jbpf 3p patches..."
+    cd "$JBPF_DIR/3p/ck" && patch -p1 --forward -r- < ../../patches/ck.patch || true
+    cd "$CURRENT_DIR"
+    cd "$JBPF_DIR/3p/mimalloc" && patch -p1 --forward -r- < ../../patches/mimalloc.patch || true
+    cd "$CURRENT_DIR"
+    cd "$JBPF_DIR/3p/ebpf-verifier" && patch -p1 --forward -r- < ../../patches/ebpf_verifier.patch || true
+    cd "$CURRENT_DIR"
+fi
 
 docker build $CACHE_FLAG \
     --build-arg BASE_IMAGE_TAG=${BASE_IMAGE_TAG} \
+    --build-arg MARCH=${MARCH} \
     -t ghcr.io/microsoft/jrtc-apps/srs-jbpf:${SRSRAN_IMAGE_TAG} -f SRS-jbpf.Dockerfile .
 
 exit 0

--- a/containers/Docker/build_srs_jbpf_sdk.sh
+++ b/containers/Docker/build_srs_jbpf_sdk.sh
@@ -3,11 +3,11 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-BASE_IMAGE_TAG=latest
 
 CURRENT_DIR=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 source $(dirname $(dirname "$CURRENT_DIR"))/set_vars.sh
 
+BASE_IMAGE_TAG=$SRSRAN_IMAGE_TAG
 
 Usage()
 {

--- a/containers/Docker/build_srs_jbpf_zmq.sh
+++ b/containers/Docker/build_srs_jbpf_zmq.sh
@@ -6,24 +6,27 @@
 CURRENT_DIR=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 source $(dirname $(dirname "$CURRENT_DIR"))/set_vars.sh
 
+MARCH=x86-64-v3
 
 Usage()
 {
    # Display Help
-   echo "Build srsRan=Jbpf base image"
+   echo "Build srsRan=Jbpf zmq image"
    echo "options:"
-   echo "[-b]    Optional base image tag.  Default='latest'"
    echo "[-s]    Optional srsRan image tag.  Default='$SRSRAN_IMAGE_TAG'"
+   echo "[-m]    Optional CPU march target.  Default='x86-64-v3' (AVX2)"
    echo
 }
 
 # Get the options
 #while getopts "b:s:c" option; do
-while getopts "s:c" option; do
+while getopts "s:m:c" option; do
 	case $option in
 
 		s) # Set image tag
 			SRSRAN_IMAGE_TAG="$OPTARG";;
+		m) # Set CPU march target
+			MARCH="$OPTARG";;
 		c) # Set image tag
 			CACHE_FLAG="--no-cache";;
 		\?) # Invalid option
@@ -35,34 +38,12 @@ done
 
 #echo BASE_IMAGE_TAG $BASE_IMAGE_TAG
 echo SRSRAN_IMAGE_TAG $SRSRAN_IMAGE_TAG
+echo MARCH $MARCH
 
 docker build $CACHE_FLAG \
     --build-arg SRS_JBPF_IMAGE_TAG=${SRSRAN_IMAGE_TAG} \
+    --build-arg MARCH=${MARCH} \
     -t ghcr.io/microsoft/jrtc-apps/srs-jbpf-zmq:${SRSRAN_IMAGE_TAG} -f SRS-jbpf-zmq.Dockerfile .
 
-
-
-# First build the jbpf_protobuf image
-
-# pushd . > /dev/null
-# cd ../../jbpf_protobuf/
-
-# # To build for a particular OS, run:
-# OS=azurelinux
-# docker build -t jbpfp-$OS:latest -f deploy/$OS.Dockerfile .
-
-# # And to create a jbpf_protobuf_cli image from that container, run:
-# docker build --build-arg builder_image=jbpfp-$OS --build-arg builder_image_tag=latest -t jbpf_protobuf_cli:latest - < deploy/jbpf_protobuf_cli.Dockerfile
-
-# popd > /dev/null
-
-
-
-# docker build $CACHE_FLAG \
-#   	--build-arg BASE_IMAGE_TAG=${BASE_IMAGE_TAG} \
-#     --build-arg SRS_JBPF_IMAGE_TAG=${SRSRAN_IMAGE_TAG} \
-#     --build-arg JBPF_PROTOBUF_BUILDER_IMAGE=jbpf_protobuf_cli \
-#     --build-arg JBPF_PROTOBUF_BUILDER_IMAGE_TAG=latest \
-#     -t ghcr.io/microsoft/jrtc-apps/srs-jbpf-sdk:${SRSRAN_IMAGE_TAG} -f SRS-jbpf-sdk.Dockerfile .
 
 exit 0

--- a/containers/Docker/build_srs_ue.sh
+++ b/containers/Docker/build_srs_ue.sh
@@ -4,6 +4,7 @@
 # Licensed under the MIT license.
 
 CACHE_FLAG=
+GCC_ARCH=x86-64-v3
 
 CURRENT_DIR=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 source $(dirname $(dirname "$CURRENT_DIR"))/set_vars.sh
@@ -14,15 +15,18 @@ Usage()
    echo "Build srsRan image"
    echo "options:"
    echo "[-s]    Optional image tag.  Default='$SRSRAN_IMAGE_TAG'"
+   echo "[-m]    Optional CPU march target.  Default='x86-64-v3' (AVX2)"
    echo "[-c]    Optional.  If included, '--no-cache- is added to the Docker build"
    echo
 }
 
 # Get the options
-while getopts "s:c" option; do
+while getopts "s:m:c" option; do
 	case $option in
 		s) # Set image tag
 			SRSRAN_IMAGE_TAG="$OPTARG";;
+		m) # Set CPU march target
+			GCC_ARCH="$OPTARG";;
 		c) # Set image tag
 			CACHE_FLAG="--no-cache";;
 		\?) # Invalid option
@@ -33,9 +37,11 @@ while getopts "s:c" option; do
 done
 
 echo SRSRAN_IMAGE_TAG $SRSRAN_IMAGE_TAG
+echo GCC_ARCH $GCC_ARCH
 
 docker build $CACHE_FLAG \
     --build-arg SRSRAN_IMAGE_TAG=${SRSRAN_IMAGE_TAG} \
+    --build-arg GCC_ARCH=${GCC_ARCH} \
     -t ghcr.io/microsoft/jrtc-apps/srs-ue:${SRSRAN_IMAGE_TAG} -f SRS-ue.Dockerfile .
 
 

--- a/containers/Docker/build_srs_ue_base.sh
+++ b/containers/Docker/build_srs_ue_base.sh
@@ -3,11 +3,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-BASE_IMAGE_TAG=latest
 CACHE_FLAG=
 
 CURRENT_DIR=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 source $(dirname $(dirname "$CURRENT_DIR"))/set_vars.sh
+
+BASE_IMAGE_TAG=$SRSRAN_IMAGE_TAG
 
 Usage()
 {


### PR DESCRIPTION
- Add configurable CPU march targets (default x86-64-v3/AVX2) to srsRAN builds
- Add VOLK profile pre-generation to fix SIMD dispatch on heterogeneous CPUs
- Add libvolk2-bin to GRC container for VOLK support
- Update build scripts to use consistent  from environment
- Apply JBPF 3p patches (ck, mimalloc, ebpf-verifier) during build
- Update image tag to srsran25.10-2